### PR TITLE
Stream input sources

### DIFF
--- a/src/bin/swyh-rs.rs
+++ b/src/bin/swyh-rs.rs
@@ -43,7 +43,7 @@ use swyh_rs::{
     ui::mainform::MainForm,
     utils::{
         audiodevices::{
-            capture_output_audio, get_default_audio_output_device, get_output_audio_devices,
+            capture_output_audio, get_default_audio_output_device, get_output_audio_devices, Device,
         },
         local_ip_address::*,
         priority::raise_priority,
@@ -53,7 +53,7 @@ use swyh_rs::{
 
 use cpal::{
     traits::{DeviceTrait, StreamTrait},
-    Sample,
+    Sample, SampleFormat,
 };
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use fltk::{
@@ -171,8 +171,8 @@ fn main() {
 
     // we need to pass some audio config data to the play function
     let audio_cfg = &audio_output_device
-        .default_output_config()
-        .expect("No default output config found");
+        .default_config_any()
+        .expect("No default input or output config found");
     let wd = WavData {
         sample_format: audio_cfg.sample_format(),
         sample_rate: audio_cfg.sample_rate(),
@@ -426,17 +426,22 @@ fn run_rms_monitor(
 /// inject silence into the audio stream to solve problems with Sonos when pusing audio
 /// contributed by @genekellyjr, see issue #71
 ///
-fn run_silence_injector(audio_output_device: &cpal::Device) {
+fn run_silence_injector(device: &Device) {
     // straight up copied from cpal docs cause I don't know syntax or anything
-    let mut supported_configs_range = audio_output_device
+    /* let mut supported_configs_range = audio_output_device
         .supported_output_configs()
         .expect("error while querying configs");
     let supported_config = supported_configs_range
         .next()
         .expect("no supported config?!")
         .with_max_sample_rate();
+    */
+    let config = device
+        .default_config_any()
+        .expect("Error while querying stream configs for the silence injector");
+    let sample_format = config.sample_format();
     let err_fn = |err| eprintln!("an error occurred on the output audio stream: {err}");
-    let config = supported_config.into();
+    let config = config.into();
 
     // CPAL 0.15 switched to dasp_sample:
     // see https://github.com/RustAudio/cpal/commit/85d773d59f1725b25002c6f04aa2eb9b43a75b76#diff-babb62f9985b4798a655658e440a565984ce15b25e63a82fc4b3cc0b54fd2a02
@@ -445,10 +450,23 @@ fn run_silence_injector(audio_output_device: &cpal::Device) {
             *sample = Sample::EQUILIBRIUM;
         }
     }
-    let stream = audio_output_device
-        .build_output_stream(&config, write_silence::<f32>, err_fn, None)
-        .unwrap();
-    stream.play().unwrap();
+
+    let device = device.as_ref();
+    let stream = match sample_format {
+        SampleFormat::F32 => device
+            .build_output_stream(&config, write_silence::<f32>, err_fn, None)
+            .unwrap(),
+        SampleFormat::I16 => device
+            .build_output_stream(&config, write_silence::<i16>, err_fn, None)
+            .unwrap(),
+        SampleFormat::U16 => device
+            .build_output_stream(&config, write_silence::<u16>, err_fn, None)
+            .unwrap(),
+        format => panic!("Unsupported sample format: {format:?}"),
+    };
+    stream
+        .play()
+        .expect("Unable to inject silence into the output stream");
 
     loop {
         thread::sleep(Duration::from_secs(1));

--- a/src/utils/audiodevices.rs
+++ b/src/utils/audiodevices.rs
@@ -11,6 +11,61 @@ use dasp_sample::ToSample;
 use log::debug;
 use parking_lot::Once;
 
+/// A [cpal::Device] with either a default input or default output config.
+pub enum Device {
+    Input(cpal::Device),
+    Output(cpal::Device),
+}
+
+impl Device {
+    // Construct a [Device] from a [cpal::Device].
+    //
+    // Devices may support both input and output.
+    // This defaults to output if both are present on one device.
+    fn from_device(device: cpal::Device) -> Option<Self> {
+        // Only use the default config for output or input
+        // Prefer output if a device supports both
+        if let Ok(conf) = device.default_output_config() {
+            debug!("    Default output stream config:\n      {:?}", conf);
+            Some(Self::Output(device))
+        } else if let Ok(conf) = device.default_input_config() {
+            debug!("    Default input stream config:\n      {:?}", conf);
+            Some(Self::Input(device))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the default [cpal::SupportedStreamConfig] regardless of device type.
+    pub fn default_config_any(
+        &self,
+    ) -> Result<cpal::SupportedStreamConfig, cpal::DefaultStreamConfigError> {
+        match self {
+            Device::Input(device) => device.default_input_config(),
+            Device::Output(device) => device.default_output_config(),
+        }
+    }
+
+    /// Device name
+    pub fn name(&self) -> Result<String, cpal::DeviceNameError> {
+        // TODO/NOTES
+        // * Maybe the String returned by Device::name should be cached
+        match self {
+            Device::Input(device) => device.name(),
+            Device::Output(device) => device.name(),
+        }
+    }
+}
+
+impl AsRef<cpal::Device> for Device {
+    fn as_ref(&self) -> &cpal::Device {
+        match self {
+            Device::Input(device) => device,
+            Device::Output(device) => device,
+        }
+    }
+}
+
 // Log all supported stream configs for both input and output devices.
 fn log_stream_configs(
     // Iterator returned by [cpal::Device::supported_input_configs] or [cpal::Device::supported_output_configs].
@@ -44,8 +99,8 @@ fn log_stream_configs(
     };
 }
 
-pub fn get_output_audio_devices() -> Option<Vec<cpal::Device>> {
-    let mut result: Vec<cpal::Device> = Vec::new();
+pub fn get_output_audio_devices() -> Option<Vec<Device>> {
+    let mut result = Vec::new();
     debug!("Supported hosts:\n  {:?}", cpal::ALL_HOSTS);
     let available_hosts = cpal::available_hosts();
     debug!("Available hosts:\n  {:?}", available_hosts);
@@ -67,9 +122,7 @@ pub fn get_output_audio_devices() -> Option<Vec<cpal::Device>> {
             // List all of the supported stream configs per device.
             log_stream_configs(device.supported_output_configs(), "output", device_index);
             log_stream_configs(device.supported_input_configs(), "input", device_index);
-            // use only device with default config
-            if let Ok(conf) = device.default_output_config() {
-                debug!("    Default output stream config:\n      {:?}", conf);
+            if let Some(device) = Device::from_device(device) {
                 result.push(device);
             }
         }
@@ -78,29 +131,30 @@ pub fn get_output_audio_devices() -> Option<Vec<cpal::Device>> {
     Some(result)
 }
 
-pub fn get_default_audio_output_device() -> Option<cpal::Device> {
+pub fn get_default_audio_output_device() -> Option<Device> {
     // audio hosts
     let _available_hosts = cpal::available_hosts();
     let default_host = cpal::default_host();
-    default_host.default_output_device()
+    default_host.default_output_device().map(Device::Output)
 }
 
 /// capture_audio_output - capture the audio stream from the default audio output device
 ///
 /// sets up an input stream for the wave_reader in the appropriate format (f32/i16/u16)
 pub fn capture_output_audio(
-    device: &cpal::Device,
+    device_wrap: &Device,
     rms_sender: Sender<Vec<f32>>,
 ) -> Option<cpal::Stream> {
+    let device = device_wrap.as_ref();
     ui_log(format!(
         "Capturing audio from: {}",
         device
             .name()
             .expect("Could not get default audio device name")
     ));
-    let audio_cfg = device
-        .default_output_config()
-        .expect("No default output config found");
+    let audio_cfg = device_wrap
+        .default_config_any()
+        .expect("No default stream config found");
     ui_log(format!("Default audio {audio_cfg:?}"));
     let mut f32_samples: Vec<f32> = Vec::with_capacity(16384);
     match audio_cfg.sample_format() {


### PR DESCRIPTION
This pull request adds support for streaming input devices as well as output. I don't modify any of the defaults (i.e. streaming output devices is still the default). My code is mostly just a light refactor of `audiodevices.rs` to support listing input devices.

To that end, I encapsulate `cpal::Device` in an `enum` that indicates whether a device is an input or output device. I implemented [AsRef](https://doc.rust-lang.org/std/convert/trait.AsRef.html) so that `cpal::Device` can be easily accessed.

Anyway, this is useful for streaming input sources, such as optical-in, without sending all of your sound or having to finagle with audio settings.