### PR TITLE
Remove spurious thread

### DIFF
--- a/src/bin/swyh-rs-cli.rs
+++ b/src/bin/swyh-rs-cli.rs
@@ -1,9 +1,6 @@
 use std::{collections::HashMap, fs::File, net::IpAddr, path::Path, thread, time::Duration};
 
-use cpal::{
-    traits::{DeviceTrait, StreamTrait},
-    Sample, SampleFormat,
-};
+use cpal::traits::StreamTrait;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use log::{debug, error, info, LevelFilter};
 use simplelog::{ColorChoice, CombinedLogger, Config, TermLogger, WriteLogger};
@@ -14,8 +11,9 @@ use swyh_rs::{
     server::streaming_server::{run_server, StreamerFeedBack},
     utils::{
         audiodevices::{
-            capture_output_audio, get_default_audio_output_device, get_output_audio_devices, Device,
+            capture_output_audio, get_default_audio_output_device, get_output_audio_devices,
         },
+        bincommon::run_silence_injector,
         commandline::Args,
         local_ip_address::{get_interfaces, get_local_addr},
         priority::raise_priority,
@@ -374,57 +372,5 @@ fn run_ssdp_updater(ssdp_tx: Sender<Renderer>, ssdp_interval_mins: f64) {
         thread::sleep(Duration::from_millis(
             (ssdp_interval_mins * 60.0 * 1000.0) as u64,
         ));
-    }
-}
-
-/// TODO: Dedup this code
-///
-/// inject silence into the audio stream to solve problems with Sonos when pusing audio
-/// contributed by @genekellyjr, see issue #71
-///
-fn run_silence_injector(device: &Device) {
-    // straight up copied from cpal docs cause I don't know syntax or anything
-    /* let mut supported_configs_range = audio_output_device
-        .supported_output_configs()
-        .expect("error while querying configs");
-    let supported_config = supported_configs_range
-        .next()
-        .expect("no supported config?!")
-        .with_max_sample_rate();
-    */
-    let config = device
-        .default_config_any()
-        .expect("Error while querying stream configs for the silence injector");
-    let sample_format = config.sample_format();
-    let err_fn = |err| eprintln!("an error occurred on the output audio stream: {err}");
-    let config = config.into();
-
-    // CPAL 0.15 switched to dasp_sample:
-    // see https://github.com/RustAudio/cpal/commit/85d773d59f1725b25002c6f04aa2eb9b43a75b76#diff-babb62f9985b4798a655658e440a565984ce15b25e63a82fc4b3cc0b54fd2a02
-    fn write_silence<T: Sample>(data: &mut [T], _: &cpal::OutputCallbackInfo) {
-        for sample in data.iter_mut() {
-            *sample = Sample::EQUILIBRIUM;
-        }
-    }
-
-    let device = device.as_ref();
-    let stream = match sample_format {
-        SampleFormat::F32 => device
-            .build_output_stream(&config, write_silence::<f32>, err_fn, None)
-            .unwrap(),
-        SampleFormat::I16 => device
-            .build_output_stream(&config, write_silence::<i16>, err_fn, None)
-            .unwrap(),
-        SampleFormat::U16 => device
-            .build_output_stream(&config, write_silence::<u16>, err_fn, None)
-            .unwrap(),
-        format => panic!("Unsupported sample format: {format:?}"),
-    };
-    stream
-        .play()
-        .expect("Unable to inject silence into the output stream");
-
-    loop {
-        thread::sleep(Duration::from_secs(1));
     }
 }

--- a/src/bin/swyh-rs.rs
+++ b/src/bin/swyh-rs.rs
@@ -43,18 +43,16 @@ use swyh_rs::{
     ui::mainform::MainForm,
     utils::{
         audiodevices::{
-            capture_output_audio, get_default_audio_output_device, get_output_audio_devices, Device,
+            capture_output_audio, get_default_audio_output_device, get_output_audio_devices,
         },
+        bincommon::run_silence_injector,
         local_ip_address::*,
         priority::raise_priority,
         ui_logger::ui_log,
     },
 };
 
-use cpal::{
-    traits::{DeviceTrait, StreamTrait},
-    Sample, SampleFormat,
-};
+use cpal::{traits::StreamTrait, Sample};
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use fltk::{
     app, dialog,
@@ -419,56 +417,5 @@ fn run_rms_monitor(
                 sum_r = 0;
             }
         }
-    }
-}
-
-///
-/// inject silence into the audio stream to solve problems with Sonos when pusing audio
-/// contributed by @genekellyjr, see issue #71
-///
-fn run_silence_injector(device: &Device) {
-    // straight up copied from cpal docs cause I don't know syntax or anything
-    /* let mut supported_configs_range = audio_output_device
-        .supported_output_configs()
-        .expect("error while querying configs");
-    let supported_config = supported_configs_range
-        .next()
-        .expect("no supported config?!")
-        .with_max_sample_rate();
-    */
-    let config = device
-        .default_config_any()
-        .expect("Error while querying stream configs for the silence injector");
-    let sample_format = config.sample_format();
-    let err_fn = |err| eprintln!("an error occurred on the output audio stream: {err}");
-    let config = config.into();
-
-    // CPAL 0.15 switched to dasp_sample:
-    // see https://github.com/RustAudio/cpal/commit/85d773d59f1725b25002c6f04aa2eb9b43a75b76#diff-babb62f9985b4798a655658e440a565984ce15b25e63a82fc4b3cc0b54fd2a02
-    fn write_silence<T: Sample>(data: &mut [T], _: &cpal::OutputCallbackInfo) {
-        for sample in data.iter_mut() {
-            *sample = Sample::EQUILIBRIUM;
-        }
-    }
-
-    let device = device.as_ref();
-    let stream = match sample_format {
-        SampleFormat::F32 => device
-            .build_output_stream(&config, write_silence::<f32>, err_fn, None)
-            .unwrap(),
-        SampleFormat::I16 => device
-            .build_output_stream(&config, write_silence::<i16>, err_fn, None)
-            .unwrap(),
-        SampleFormat::U16 => device
-            .build_output_stream(&config, write_silence::<u16>, err_fn, None)
-            .unwrap(),
-        format => panic!("Unsupported sample format: {format:?}"),
-    };
-    stream
-        .play()
-        .expect("Unable to inject silence into the output stream");
-
-    loop {
-        thread::sleep(Duration::from_secs(1));
     }
 }

--- a/src/bin/swyh-rs.rs
+++ b/src/bin/swyh-rs.rs
@@ -207,14 +207,13 @@ fn main() {
         }
     }
 
-    // If silence injector is on, start the "silence_injector" thread
-    if let Some(true) = CONFIG.read().inject_silence {
-        let _ = thread::Builder::new()
-            .name("silence_injector".into())
-            .stack_size(4 * 1024 * 1024)
-            .spawn(move || run_silence_injector(&audio_output_device))
-            .unwrap();
-    }
+    // If silence injector is on, create a silence injector stream.
+    let _silence_stream = if let Some(true) = CONFIG.read().inject_silence {
+        ui_log("Injecting silence into the output stream".to_owned());
+        Some(run_silence_injector(&audio_output_device))
+    } else {
+        None
+    };
 
     // now start the SSDP discovery update thread with a Crossbeam channel for renderer updates
     // the discovered renderers will be kept in this list

--- a/src/utils/bincommon.rs
+++ b/src/utils/bincommon.rs
@@ -1,0 +1,62 @@
+//! Tools common to both the swyh-rs GUI and CLI.
+
+use std::{thread, time::Duration};
+
+use cpal::{
+    traits::{DeviceTrait, StreamTrait},
+    Sample, SampleFormat,
+};
+
+use super::audiodevices::Device;
+
+/// TODO: Dedup this code
+///
+/// inject silence into the audio stream to solve problems with Sonos when pusing audio
+/// contributed by @genekellyjr, see issue #71
+///
+pub fn run_silence_injector(device: &Device) {
+    // straight up copied from cpal docs cause I don't know syntax or anything
+    /* let mut supported_configs_range = audio_output_device
+        .supported_output_configs()
+        .expect("error while querying configs");
+    let supported_config = supported_configs_range
+        .next()
+        .expect("no supported config?!")
+        .with_max_sample_rate();
+    */
+    let config = device
+        .default_config_any()
+        .expect("Error while querying stream configs for the silence injector");
+    let sample_format = config.sample_format();
+    let err_fn = |err| eprintln!("an error occurred on the output audio stream: {err}");
+    let config = config.into();
+
+    // CPAL 0.15 switched to dasp_sample:
+    // see https://github.com/RustAudio/cpal/commit/85d773d59f1725b25002c6f04aa2eb9b43a75b76#diff-babb62f9985b4798a655658e440a565984ce15b25e63a82fc4b3cc0b54fd2a02
+    fn write_silence<T: Sample>(data: &mut [T], _: &cpal::OutputCallbackInfo) {
+        for sample in data.iter_mut() {
+            *sample = Sample::EQUILIBRIUM;
+        }
+    }
+
+    let device = device.as_ref();
+    let stream = match sample_format {
+        SampleFormat::F32 => device
+            .build_output_stream(&config, write_silence::<f32>, err_fn, None)
+            .unwrap(),
+        SampleFormat::I16 => device
+            .build_output_stream(&config, write_silence::<i16>, err_fn, None)
+            .unwrap(),
+        SampleFormat::U16 => device
+            .build_output_stream(&config, write_silence::<u16>, err_fn, None)
+            .unwrap(),
+        format => panic!("Unsupported sample format: {format:?}"),
+    };
+    stream
+        .play()
+        .expect("Unable to inject silence into the output stream");
+
+    loop {
+        thread::sleep(Duration::from_secs(1));
+    }
+}

--- a/src/utils/bincommon.rs
+++ b/src/utils/bincommon.rs
@@ -1,29 +1,17 @@
 //! Tools common to both the swyh-rs GUI and CLI.
 
-use std::{thread, time::Duration};
-
 use cpal::{
     traits::{DeviceTrait, StreamTrait},
-    Sample, SampleFormat,
+    Sample, SampleFormat, Stream,
 };
 
 use super::audiodevices::Device;
 
-/// TODO: Dedup this code
-///
-/// inject silence into the audio stream to solve problems with Sonos when pusing audio
+/// Inject silence into the audio stream to solve problems with Sonos when pausing audio.
 /// contributed by @genekellyjr, see issue #71
 ///
-pub fn run_silence_injector(device: &Device) {
-    // straight up copied from cpal docs cause I don't know syntax or anything
-    /* let mut supported_configs_range = audio_output_device
-        .supported_output_configs()
-        .expect("error while querying configs");
-    let supported_config = supported_configs_range
-        .next()
-        .expect("no supported config?!")
-        .with_max_sample_rate();
-    */
+/// Streams are asynchronous, so the silence stream is just returned to keep the object alive.
+pub fn run_silence_injector(device: &Device) -> Stream {
     let config = device
         .default_config_any()
         .expect("Error while querying stream configs for the silence injector");
@@ -55,8 +43,5 @@ pub fn run_silence_injector(device: &Device) {
     stream
         .play()
         .expect("Unable to inject silence into the output stream");
-
-    loop {
-        thread::sleep(Duration::from_secs(1));
-    }
+    stream
 }

--- a/src/utils/commandline.rs
+++ b/src/utils/commandline.rs
@@ -73,7 +73,7 @@ Recognized options:
     -f (--format) string : streaming_format (lpcm/flac/wav) [LPCM]
     -o (--player_ip) string : the player ip address [last used player]
     -e (--ip_address) string : ip address of the network interface [last used]
-    -S (--inject_silence) string : inject silence into stream (y[es]/n[o]) [n]
+    -S (--inject_silence) bool : inject silence into stream (bool) [false]
 "#
         );
         println!("{:?}", self);
@@ -191,15 +191,7 @@ Recognized options:
                 }
                 Short('I') | Long("inject_silence") => {
                     if let Ok(inject) = argparser.value() {
-                        let inject = inject.to_str().unwrap_or("n");
-                        match inject {
-                            "y" | "yes" => self.inject_silence = Some(true),
-                            "n" | "no" => self.inject_silence = Some(false),
-                            _ => {
-                                println!("invalid inject option {inject}");
-                                self.usage();
-                            }
-                        }
+                        self.inject_silence = Some(inject.parse().unwrap());
                     }
                 }
                 _ => (),

--- a/src/utils/commandline.rs
+++ b/src/utils/commandline.rs
@@ -24,6 +24,7 @@ pub struct Args {
     pub streaming_format: Option<StreamingFormat>,
     pub player_ip: Option<String>,
     pub ip_address: Option<String>,
+    pub inject_silence: Option<bool>,
 }
 
 impl Default for Args {
@@ -49,6 +50,7 @@ impl Args {
             streaming_format: None,
             player_ip: None,
             ip_address: None,
+            inject_silence: None,
         }
     }
 
@@ -57,8 +59,8 @@ impl Args {
         println!(
             r#"
 Recognized options:
-    -h (--help) : print usage 
-    -n (--no_run) : dry-run, don't start streaming  
+    -h (--help) : print usage
+    -n (--no_run) : dry-run, don't start streaming
     -c (--config_id) string : config_id [_cli]
     -p (--server_port) u16 : server_port [5901]
     -a (--auto_reconnect) bool : auto reconnect [true]
@@ -71,6 +73,7 @@ Recognized options:
     -f (--format) string : streaming_format (lpcm/flac/wav) [LPCM]
     -o (--player_ip) string : the player ip address [last used player]
     -e (--ip_address) string : ip address of the network interface [last used]
+    -S (--inject_silence) string : inject silence into stream (y[es]/n[o]) [n]
 "#
         );
         println!("{:?}", self);
@@ -183,6 +186,19 @@ Recognized options:
                         } else {
                             println!("invalid ip address {ip}");
                             self.usage();
+                        }
+                    }
+                }
+                Short('I') | Long("inject_silence") => {
+                    if let Ok(inject) = argparser.value() {
+                        let inject = inject.to_str().unwrap_or("n");
+                        match inject {
+                            "y" | "yes" => self.inject_silence = Some(true),
+                            "n" | "no" => self.inject_silence = Some(false),
+                            _ => {
+                                println!("invalid inject option {inject}");
+                                self.usage();
+                            }
                         }
                     }
                 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod audiodevices;
+pub mod bincommon;
 pub mod commandline;
 pub mod configuration;
 pub mod escape;


### PR DESCRIPTION
`[cpal::Stream]` is asynchronous, so it will play as long as the object is alive. Currently, `swyh-rs` busy waits in two threads for injecting silence. I eliminated both of those threads by storing the stream object in an `Option`.

## Smaller changes
* Added a command line switch to enable or disable the silence injectors
* Refactor `run_silence_injector` into a new module. The function was duplicated across both binaries.