### PR TITLE
[nix] Add receipts for building with nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,116 @@
+{
+  rustPlatform,
+  pkg-config,
+  cmake,
+  rust,
+  alsa-lib,
+  xorg,
+  pango,
+  glib,
+  cairo,
+  mkShellNoCC,
+  rust-analyzer-unwrapped,
+  rust-bin,
+  lib,
+  withGui ? true,
+  withCli ? true,
+}:
+assert withGui || withCli; let
+  buildInputs =
+    [
+      alsa-lib
+    ]
+    ++ (lib.lists.optionals withGui [
+      xorg.libXft
+      xorg.libXext
+      xorg.libXinerama
+      xorg.libXcursor
+      xorg.libXfixes
+      cairo
+      pango
+      glib
+    ]);
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
+  rust = rust-bin.stable.latest.default;
+  pname =
+    if withGui && withCli
+    then "swyh-rs"
+    else if withGui
+    then "swyh-rs-gui"
+    else "swyh-rs-cli";
+  swyh-rs = rustPlatform.buildRustPackage rec {
+    version = "1.9.9";
+    inherit nativeBuildInputs buildInputs pname;
+    # Filter-out generated, version-control and nix-related files to prevent
+    # cache invalidation while editing them
+    src = lib.cleanSourceWith {
+      filter = path: type:
+        with builtins; let
+          bn = baseNameOf path;
+        in
+          (!lib.hasSuffix ".nix" bn) && bn != "flake.lock";
+      src = lib.cleanSource ./.;
+    };
+    cargoLock.lockFile = ./Cargo.lock;
+    buildNoDefaultFeatures = true;
+    buildPhase =
+      ''
+        runHook preBuild
+
+        safePostBuildHooks=("''${postBuildHooks[@]}")
+        postBuildHooks=()
+        preBuildHooks=()
+      ''
+      + (lib.optionalString withGui ''
+        cargoBuildFeatures="gui"
+        cargoBuildHook
+      '')
+      + (lib.optionalString withCli ''
+        cargoBuildFeatures="cli"
+        cargoBuildHook
+      '')
+      + ''
+        postBuildHooks=("''${safePostBuildHooks[@]}")
+        runHook postBuild
+      '';
+    postInstall =
+      if withGui
+      then ''
+        mv $out/bin/swyh-rs $out/bin/swyh-rs-gui
+        ln -s swyh-rs-gui $out/bin/swyh-rs
+      ''
+      else ''
+        ln -s swyh-rs-cli $out/bin/swyh-rs
+      '';
+    meta = with lib; {
+      description = "Stream What You Hear written in rust, inspired by SWYH";
+      homepage = "https://github.com/dheijl/swyh-rs";
+      license = licenses.mit;
+      maintainers = [
+        {
+          name = "Yury Shvedov";
+          email = "mestofel13@gmail.com";
+          github = "ein-shved";
+          githubId = 3513222;
+        }
+      ];
+    };
+  };
+  devShell = mkShellNoCC {
+    buildInputs =
+      [
+        rust
+        rust-analyzer-unwrapped
+      ]
+      ++ buildInputs
+      ++ nativeBuildInputs;
+    RUST_SRC_PATH = "${rust}/lib/rustlib/src/rust/library";
+  };
+in
+  swyh-rs
+  // {
+    inherit devShell;
+  }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1707786466,
+        "narHash": "sha256-yLPfrmW87M2qt+8bAmwopJawa+MJLh3M9rUbXtpUc1o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "01885a071465e223f8f68971f864b15829988504",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1707963067,
+        "narHash": "sha256-1vmNGzAIenei+keS8vIUNYVkEGwEwF+3FR7/bXU/r18=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "23f224428779539eb4dc13f6a77c97ffe4680d74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = ''
+    Stream What You Hear written in rust, inspired by SWYH
+  '';
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      flake-utils.follows = "flake-utils";
+    };
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-23.11;
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    rust-overlay,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        overlays = [(import rust-overlay)];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        rust = pkgs.rust-bin.stable.latest.default;
+        swyh-rs =
+          pkgs.callPackage ./default.nix {};
+      in {
+        packages = {
+          inherit swyh-rs;
+          swyh-rs-cli = swyh-rs.override {withGui = false;};
+          swyh-rs-gui = swyh-rs.override {withCli = false;};
+          default = swyh-rs;
+        };
+        devShells = {
+          swyh-rs = swyh-rs.devShell;
+          default = swyh-rs.devShell;
+        };
+        formatter = pkgs.alejandra;
+      }
+    );
+}


### PR DESCRIPTION
Not sure, if you happy to see this receipts in mainstream, but with NIX the build instruction degenerates to one simple line:
```bash
nix build github:dheijl/swyh-rs
```
It is reliable and portable, you do not even need to clone the repo.

If you never used NIX you can try it on my fork of your project:

```bash
apt install nix
nix --extra-experimental-features 'flakes nix-command' run github:ein-shved/swyh-rs/nix
```