### PR TITLE
Makinkg swyh a service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +589,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "local-ip-address"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63e1499d2495be571af92e9ca9dca4e7bf26c47b87cb8d0c6100825e521dd6b"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +676,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf2aae958bd232cac5069850591667ad422d263686d75b52a065f9badeee5a3"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "neli"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1100229e06604150b3becd61a4965d5c70f3be1759544ea7274166f4be41ef43"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168194d373b1e134786274020dae7fc5513d565ea2ebb9bc9ff17ffb69106d4"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1067,6 +1110,7 @@ dependencies = [
  "if-addrs",
  "lexopt",
  "libc",
+ "local-ip-address",
  "log",
  "once_cell",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ ureq = { version = "2.9.5", default-features = false, features = [
 ] }
 url = "2.5.0"
 xml-rs = "0.8.19"
+local-ip-address = "0.6.0"
 [target.'cfg(windows)'.dependencies]
 fltk = { version = "1.4.24", features = ["use-ninja"], optional = true }
 windows = { version = "0.52.0", features = [

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,19 @@
     nixpkgs,
     flake-utils,
     rust-overlay,
-  }:
+  }: let
+    module = {
+        imports = [ ./module.nix ];
+        nixpkgs.overlays = [
+          (import rust-overlay)
+          (prev: cur: rec {
+            swyh-rs = cur.callPackage ./default.nix {};
+            swyh-rs-cli = swyh-rs.override {withGui = false;};
+            swyh-rs-gui = swyh-rs.override {withCli = false;};
+          })
+        ];
+      };
+  in
     flake-utils.lib.eachDefaultSystem (
       system: let
         overlays = [(import rust-overlay)];
@@ -39,6 +51,7 @@
           default = swyh-rs.devShell;
         };
         formatter = pkgs.alejandra;
+        nixosModule = module;
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
           swyh-rs-cli = swyh-rs.override {withGui = false;};
           swyh-rs-gui = swyh-rs.override {withCli = false;};
           default = swyh-rs;
+          test = pkgs.callPackage ./test.nix {inherit module;};
         };
         devShells = {
           swyh-rs = swyh-rs.devShell;

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,149 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: {
+  options.services.swyh = with lib.types;
+    lib.mkOption {
+      description = ''
+        The Stream What You Hear service
+      '';
+      default = {};
+      type = attrsOf (submodule {
+        options = {
+          enable = lib.mkEnableOption "Stream What You Hear service";
+          server_port = lib.mkOption {
+            description = "The port to listen on";
+            type = port;
+            default = 5901;
+          };
+          auto_resume = lib.mkOption {
+            description = "Atomatically resume playing";
+            type = bool;
+            default = false;
+          };
+          sound_source = lib.mkOption {
+            description = "Index of input device (null for default)";
+            type = nullOr int;
+            default = null;
+          };
+          log_level = lib.mkOption {
+            description = "The log level: 'info' or 'debug'";
+            type =
+              str
+              // {
+                check = x: builtins.elem x ["info" "Info" "INFO" "debug" "Debug" "DEBUG"];
+              };
+            default = "info";
+          };
+          ssdp = lib.mkEnableOption "SSDP discovery";
+          ssdp_interval_mins = lib.mkOption {
+            description = "Timeout between ssdp discovery";
+            type = numbers.positive;
+            default = 10.0;
+          };
+          auto_reconnect = lib.mkOption {
+            description = "Whether to reconnect ssdp device";
+            type = bool;
+            default = true;
+          };
+          use_wave_format = lib.mkOption {
+            description = "Wheter to use wave format";
+            type = bool;
+            default = true;
+          };
+          bits_per_sample = lib.mkOption {
+            description = "Bits per sample";
+            type = ints.positive // {check = x: builtins.elem x [16 24];};
+            default = 16;
+          };
+          streaming_format = lib.mkOption {
+            description = "Streaming format: lpcm, wav, RF64 of flac";
+            type =
+              str
+              // {
+                check = x:
+                  builtins.elem x [
+                    "Lpcm"
+                    "Wav"
+                    "Rf64"
+                    "Flac"
+                  ];
+              };
+            default = "Lpcm";
+          };
+          monitor_rms = lib.mkOption {
+            description = "Whether to enable RMS monitoring";
+            type = bool;
+            default = false;
+          };
+          capture_timeout = lib.mkOption {
+            description = "Capture timeout";
+            type = ints.positive;
+            default = 2000;
+          };
+          inject_silence = lib.mkOption {
+            description = "Whether to inject silence";
+            type = bool;
+            default = false;
+          };
+          package = lib.mkOption {
+            description = ''
+              The package to use. This is better to use "swyh-rs-cli" package when
+              you are using it only as service, cause it does not require graphics
+              dependencies. You are beter to set this to "swyh-rs" if you planned to
+              use GUI version too, to optimize building time.
+            '';
+            type = package;
+            default = pkgs.swyh-rs-cli;
+          };
+        };
+      });
+    };
+
+  config = let
+    cfg = config.services.swyh;
+    filter = name: cfg: cfg.enable;
+    mkService = name: cfg:
+      lib.nameValuePair "swyh-${name}" {
+        wantedBy = ["multi-user.target"];
+        after = ["systemd-networkd-wait-online.service" "network-online.target" ];
+        wants = ["systemd-networkd-wait-online.service" "network-online.target" ];
+        serviceConfig = {
+          ExecStart = ''
+            ${cfg.package}/bin/swyh-rs-cli        \
+              -C ${mkConfig name cfg}             \
+              ${lib.optionalString cfg.ssdp "-x"}
+          '';
+          User = "swyh";
+          LogsDirectory = "swyh";
+          LogsDirectoryMode = "750";
+        };
+      };
+    hasAny = lib.foldlAttrs (acc: name: cfg: acc || cfg.enable) false cfg;
+    mkConfig = name: cfg: let
+      configuration =
+        (builtins.removeAttrs cfg ["package" "enable" "sound_source" "ssdp"])
+        // (
+          lib.optionalAttrs (cfg.sound_source != null) {
+            sound_source_index = cfg.sound_source;
+          }
+        )
+        // {
+          config_id = "_${name}";
+          config_dir = "/var/log/swyh";
+        };
+      format = pkgs.formats.toml {};
+    in
+      format.generate "config_${name}.toml" {inherit configuration;};
+    ports = lib.mapAttrsToList (name: cfg: cfg.server_port) cfg;
+  in {
+    systemd.services = lib.mapAttrs' mkService cfg;
+    users.users.swyh = lib.mkIf hasAny {
+      group = "audio";
+      isSystemUser = true;
+    };
+    networking.firewall.allowedTCPPorts = ports;
+  };
+}

--- a/src/openhome/rendercontrol.rs
+++ b/src/openhome/rendercontrol.rs
@@ -688,7 +688,7 @@ pub fn discover(rmap: &HashMap<String, Renderer>, logger: &dyn Fn(&str)) -> Opti
     debug!("SSDP discovery started");
 
     // get the address of the selected interface
-    let ip = CONFIG.read().last_network.clone();
+    let ip = CONFIG.read().last_network.clone().unwrap();
     info!("running SSDP on {ip}");
     let local_addr: IpAddr = ip.parse().unwrap();
     let bind_addr = SocketAddr::new(local_addr, 0);

--- a/src/utils/local_ip_address.rs
+++ b/src/utils/local_ip_address.rs
@@ -1,23 +1,11 @@
 use if_addrs::IfAddr;
-use std::net::{IpAddr, UdpSocket};
+use std::net::IpAddr;
+use local_ip_address::local_ip;
 
 /// `get_local_address` - get the local ip address, return an `Option<String>`. when it fails, return `None`.
 #[must_use]
-pub fn get_local_addr() -> Option<IpAddr> {
-    // bind to IN_ADDR_ANY, can be multiple interfaces/addresses
-    // try to connect to Google DNS so that we bind to an interface connected to the internet
-    let Ok(socket) = UdpSocket::bind("0.0.0.0:0") else {
-        return None;
-    };
-    match socket.connect("8.8.8.8:80") {
-        Ok(()) => (),
-        Err(_) => return None,
-    };
-    // now we can return the IP address of this interface
-    match socket.local_addr() {
-        Ok(addr) => Some(addr.ip()),
-        Err(_) => None,
-    }
+pub fn get_local_addr() -> Result<IpAddr, local_ip_address::Error> {
+    local_ip()
 }
 
 #[must_use]

--- a/test.nix
+++ b/test.nix
@@ -1,0 +1,103 @@
+{
+  nixosTest,
+  module,
+  system,
+  linkFarm,
+}: let
+  oldFlake = builtins.getFlake "github:dheijl/swyh-rs/90277704156a3caacbcc375a892188bb0e3a7029";
+  oldPackage = oldFlake.packages."${system}".swyh-rs-cli;
+  swyh-rs-cli-old =
+    linkFarm "swyh-rs-cli-old"
+    {
+      "bin/swyh-rs-cli-old" = "${oldPackage}/bin/swyh-rs-cli";
+    };
+  modules = [ module ];
+in
+  nixosTest {
+    name = "swyh";
+    /*
+    We have three tests here:
+    1. Machine with service with default audio input device
+    2. Machine with service with selected audio input device
+    3. Machine with manually run of swyh-rs-cli
+
+    First two just checked that services selects correct audio inputs
+    TODO(Shvedov): We should to add test for samples going through loopbacks
+
+    The third runs the old version of swyh-rs-cli (got with oldFlake above)
+    utility to create default configuration before changes. Then it run actual
+    (from current pkgs) to check whether it able to run with old configuration
+    (migrate).
+    TODO(Shvedov): Test the behaviour of configuration
+    TODO(Shvedov): Add GUI tests with
+      [OCR](https://nixos.org/manual/nixos/stable/#test-opt-enableOCR)
+    */
+    nodes.default = {
+      imports = modules;
+      services.swyh.test = {
+        enable = true;
+      };
+      boot.kernelModules = ["snd-aloop"];
+    };
+    nodes.audio-1 = {
+      imports = modules;
+      services.swyh.test = {
+        enable = true;
+        sound_source = 1;
+        auto_resume = true;
+      };
+      boot.kernelModules = ["snd-aloop"];
+    };
+    nodes.migration = {pkgs, ...}: {
+      imports = modules;
+      boot.kernelModules = ["snd-aloop"];
+      environment.systemPackages = [
+        swyh-rs-cli-old
+        pkgs.swyh-rs-cli
+      ];
+    };
+    testScript = {nodes, ...}: ''
+      def read_logs(machine, path):
+        from pathlib import Path
+        p = Path(path)
+        shared = machine.out_dir
+        machine.copy_from_vm(path)
+        res = ""
+        with open(shared / p.name) as f:
+          res = f.read()
+        return res
+
+      def check_machine(machine, card: str):
+        machine.wait_for_unit("swyh-test.service")
+        if card not in read_logs(machine, "/var/log/swyh/log_test.txt"):
+            raise Exception("Wrong card selected")
+
+      # Test first machine with default device
+      check_machine(default, "Selected audio source: default:CARD=Loopback[#0]")
+
+      # Test second machine with selected device
+      check_machine(audio_1, "Selected audio source: sysdefault:CARD=Loopback[#1]")
+
+      ### Migration test
+
+      migration.wait_for_unit("network-online.target")
+
+      # Run old version and check whether it created configuration and run
+      # server
+      (_, stdout) = migration.execute("swyh-rs-cli-old", check_return=False, timeout=5)
+      logs = read_logs(migration, "/root/.swyh-rs/log_cli.txt")
+      if "Creating a new default config /root/.swyh-rs/config_cli.toml" not in str(stdout):
+        raise Exception("Old version creating config logs failed")
+      if "The streaming server is listening on" not in logs:
+        raise Exception("Old version start logs failed")
+
+      # Run old version and check whether it reads configuration and run
+      # server
+      (_, stdout) = migration.execute("swyh-rs-cli", check_return=False, timeout=5)
+      logs = read_logs(migration, "/root/.swyh-rs/log_cli.txt")
+      if "Creating a new default config" in str(stdout):
+        raise Exception("New version wrong creating config logs")
+      if "The streaming server is listening on" not in logs:
+        raise Exception("New version start logs failed")
+    '';
+  }


### PR DESCRIPTION
I am going to use swyh as audio streaming service at home onboard of allwiner-based OrangePI Zero 2 device. 

For this, I updated CLI version to accept its configuration directly as file, change configuration reading to accept defaults and changed some of its types to be more rust-styled Options.

Added module for NixOS, so you can fully configure `swyh-rs` as several services in couple of lines:

```nix
    services.swyh = {
        my-default-swyh = {
            auto_resume = true;
            ssdp_interval_mins = 1.5;
        };
        extra-swyh = {
            server_port = 5902;
            sound_source = 2;
        };
    };
```

Additionally added simple tests based on nixos-test framework: two for testing configurations and one - for migration.
Run them with `nix build .#test`, or add github action for [auto-testing with nix](https://nix.dev/tutorials/nixos/continuous-integration-github-actions#caching-builds-using-github-actions-cache)