### PR TITLE
add range header logic (necessary for supporting Linn devices)

### DIFF
--- a/locales/de-DE/main.ftl
+++ b/locales/de-DE/main.ftl
@@ -143,3 +143,5 @@ srv-head-terminated = =>HTTP-HEAD-Verbindung mit { $addr } beendet [{ $error }]
 srv-unsupported-method = Nicht unterstützte HTTP-Methode { $method } von { $addr }
 srv-bad-request = Unbekannte Anfrage '{ $url }' von '{ $addr }'
 srv-stream-terminated = =>HTTP-Streaming-Anfrage mit { $addr } beendet [{ $error }]
+
+srv-range-not-satisfiable = Range-Anfrage von { $addr } nicht erfüllbar, Antwort 416

--- a/locales/en-US/main.ftl
+++ b/locales/en-US/main.ftl
@@ -143,3 +143,5 @@ srv-head-terminated = =>Http HEAD connection with { $addr } terminated [{ $error
 srv-unsupported-method = Unsupported HTTP method request { $method } from { $addr }
 srv-bad-request = Unrecognized request '{ $url }' from '{ $addr }'
 srv-stream-terminated = =>Http streaming request with { $addr } terminated [{ $error }]
+
+srv-range-not-satisfiable = Range request from { $addr } not satisfiable, responding 416

--- a/locales/es-ES/main.ftl
+++ b/locales/es-ES/main.ftl
@@ -143,3 +143,5 @@ srv-head-terminated = =>Conexión HTTP HEAD con { $addr } terminada [{ $error }]
 srv-unsupported-method = Solicitud de método HTTP no compatible { $method } desde { $addr }
 srv-bad-request = Solicitud no reconocida '{ $url }' desde '{ $addr }'
 srv-stream-terminated = =>Solicitud de streaming HTTP con { $addr } terminada [{ $error }]
+
+srv-range-not-satisfiable = Solicitud de rango de { $addr } no satisfacible, respondiendo 416

--- a/locales/fr-FR/main.ftl
+++ b/locales/fr-FR/main.ftl
@@ -143,3 +143,5 @@ srv-head-terminated = =>Connexion HTTP HEAD avec { $addr } terminée [{ $error }
 srv-unsupported-method = Méthode HTTP non prise en charge { $method } depuis { $addr }
 srv-bad-request = Requête non reconnue '{ $url }' depuis '{ $addr }'
 srv-stream-terminated = =>Requête de streaming HTTP avec { $addr } terminée [{ $error }]
+
+srv-range-not-satisfiable = Requête de plage de { $addr } non satisfaisable, réponse 416

--- a/locales/it-IT/main.ftl
+++ b/locales/it-IT/main.ftl
@@ -143,3 +143,5 @@ srv-head-terminated = =>Connessione HTTP HEAD con { $addr } terminata [{ $error 
 srv-unsupported-method = Metodo HTTP non supportato { $method } da { $addr }
 srv-bad-request = Richiesta non riconosciuta '{ $url }' da '{ $addr }'
 srv-stream-terminated = =>Richiesta di streaming HTTP con { $addr } terminata [{ $error }]
+
+srv-range-not-satisfiable = Richiesta di intervallo da { $addr } non soddisfacibile, risposta 416

--- a/locales/ja-JP/main.ftl
+++ b/locales/ja-JP/main.ftl
@@ -143,3 +143,5 @@ srv-head-terminated = =>{ $addr } との HTTP HEAD 接続が終了しました [
 srv-unsupported-method = { $addr } からの未サポート HTTP メソッドリクエスト { $method }
 srv-bad-request = '{ $addr }' からの認識できないリクエスト '{ $url }'
 srv-stream-terminated = =>{ $addr } との HTTP ストリーミングリクエストが終了しました [{ $error }]
+
+srv-range-not-satisfiable = { $addr } からの範囲リクエストは満たせません、416 を返します

--- a/locales/nl-NL/main.ftl
+++ b/locales/nl-NL/main.ftl
@@ -144,3 +144,5 @@ srv-head-terminated = =>Http HEAD verbinding met { $addr } beëindigd [{ $error 
 srv-unsupported-method = Niet-ondersteunde HTTP methode { $method } van { $addr }
 srv-bad-request = Onherkenbaar verzoek '{ $url }' van '{ $addr }'
 srv-stream-terminated = =>Http streaming verzoek met { $addr } beëindigd [{ $error }]
+
+srv-range-not-satisfiable = Bereikverzoek van { $addr } niet vervulbaar, antwoord 416

--- a/locales/zh-CN/main.ftl
+++ b/locales/zh-CN/main.ftl
@@ -143,3 +143,5 @@ srv-head-terminated = =>与 { $addr } 的 HTTP HEAD 连接已终止 [{ $error }]
 srv-unsupported-method = 来自 { $addr } 的不支持的 HTTP 方法请求 { $method }
 srv-bad-request = 来自 '{ $addr }' 的无法识别的请求 '{ $url }'
 srv-stream-terminated = =>与 { $addr } 的 HTTP 流媒体请求已终止 [{ $error }]
+
+srv-range-not-satisfiable = 来自 { $addr } 的范围请求无法满足，响应 416

--- a/src/audio/rwstream.rs
+++ b/src/audio/rwstream.rs
@@ -57,6 +57,7 @@ impl ChannelStream {
         tx: Sender<AudioSamples>,
         rx: Receiver<AudioSamples>,
         context: &StreamingContext,
+        header_offset: usize,
     ) -> ChannelStream {
         let flac_channel = if context.streaming_format == StreamingFormat::Flac {
             Some(FlacChannel::new(
@@ -69,7 +70,7 @@ impl ChannelStream {
             None
         };
         let capture_timeout = u64::from(get_config().capture_timeout.unwrap_or(5));
-        let wav_hdr = match context.streaming_format {
+        let mut wav_hdr = match context.streaming_format {
             StreamingFormat::Wav => {
                 create_wav_hdr(context.sample_rate, context.bits_per_sample as u16)
             }
@@ -78,6 +79,10 @@ impl ChannelStream {
             }
             _ => Vec::new(),
         };
+        // Trim the header when the client requested Range: bytes=N- (N within header)
+        if header_offset > 0 && !wav_hdr.is_empty() {
+            wav_hdr.drain(..header_offset.min(wav_hdr.len()));
+        }
         let chs = ChannelStream {
             s: tx,
             r: rx,

--- a/src/server/streaming_server.rs
+++ b/src/server/streaming_server.rs
@@ -97,12 +97,13 @@ pub fn run_server(
                     streaming_ctx.set_streaming_params(&sp);
                     debug!("{streaming_ctx:?}");
                     // handle response, streaming if GET, headers only otherwise
+                    let range = parse_range_header(rq.headers());
                     match *rq.method() {
                         Method::Get => {
-                            streaming_request(&streaming_ctx, &feedback_tx_c, rq);
+                            streaming_request(&streaming_ctx, &feedback_tx_c, rq, range);
                         }
                         Method::Head => {
-                            head_request(&streaming_ctx, rq);
+                            head_request(&streaming_ctx, rq, range);
                         }
                         _ => {
                             invalid_request(&streaming_ctx, rq);
@@ -150,7 +151,27 @@ fn streaming_request(
     streaming_ctx: &StreamingContext,
     feedback_channel: &Sender<MessageType>,
     request: tiny_http::Request,
+    range: Option<RangeSpec>,
 ) {
+    // Determine HTTP status code and how many header bytes to skip based on the Range request.
+    // Linn streamers typically send `Range: bytes=0-`; we respond 206 and start from byte 0.
+    // A range starting within the WAV/RF64 header is also satisfiable by trimming the header.
+    // Anything else (bounded range or offset past the header) is rejected with 416.
+    let (status_code, header_offset) = match &range {
+        None => (200u16, 0usize),
+        Some(RangeSpec::Bounded) => {
+            return range_not_satisfiable(streaming_ctx, request);
+        }
+        Some(RangeSpec::From(start)) => {
+            let hdr_size = wav_header_size(streaming_ctx) as u64;
+            if *start <= hdr_size {
+                (206u16, *start as usize)
+            } else {
+                return range_not_satisfiable(streaming_ctx, request);
+            }
+        }
+    };
+
     ui_log(
         LogCategory::Info,
         &fl!(
@@ -160,11 +181,15 @@ fn streaming_request(
         ),
     );
     // get the dlna headers
-    let headers = get_dlna_headers(streaming_ctx);
+    let mut headers = get_dlna_headers(streaming_ctx);
+    if status_code == 206 {
+        let cr = content_range_value(streaming_ctx, header_offset);
+        headers.push(Header::from_bytes(&b"Content-Range"[..], cr.as_bytes()).unwrap());
+    }
 
     // create the channelstream that receives the samples and streams them on demand
     let (tx, rx) = unbounded();
-    let channel_stream = ChannelStream::new(tx, rx, streaming_ctx);
+    let channel_stream = ChannelStream::new(tx, rx, streaming_ctx, header_offset);
     let nclients = {
         let mut clients = get_clients_mut();
         clients.insert(streaming_ctx.remote_addr.clone(), channel_stream.clone());
@@ -203,7 +228,7 @@ fn streaming_request(
         ),
     );
     let response = Response::new(
-        tiny_http::StatusCode(200),
+        tiny_http::StatusCode(status_code),
         headers,
         channel_stream,
         streaming_ctx.streamsize,
@@ -253,13 +278,30 @@ fn streaming_request(
 }
 
 /// HEAD METHOD request
-fn head_request(streaming_ctx: &StreamingContext, rq: tiny_http::Request) {
+fn head_request(streaming_ctx: &StreamingContext, rq: tiny_http::Request, range: Option<RangeSpec>) {
     debug!("HEAD rq from {}", streaming_ctx.remote_addr);
+    let (status_code, header_offset) = match &range {
+        None => (200u16, 0usize),
+        Some(RangeSpec::Bounded) => {
+            return range_not_satisfiable(streaming_ctx, rq);
+        }
+        Some(RangeSpec::From(start)) => {
+            let hdr_size = wav_header_size(streaming_ctx) as u64;
+            if *start <= hdr_size {
+                (206u16, *start as usize)
+            } else {
+                return range_not_satisfiable(streaming_ctx, rq);
+            }
+        }
+    };
     // get the dlna headers
-    let headers = get_dlna_headers(streaming_ctx);
-
+    let mut headers = get_dlna_headers(streaming_ctx);
+    if status_code == 206 {
+        let cr = content_range_value(streaming_ctx, header_offset);
+        headers.push(Header::from_bytes(&b"Content-Range"[..], cr.as_bytes()).unwrap());
+    }
     let response = Response::new(
-        tiny_http::StatusCode(200),
+        tiny_http::StatusCode(status_code),
         headers,
         io::empty(),
         Some(0),
@@ -366,10 +408,75 @@ fn get_std_headers() -> Vec<Header> {
     headers.push(Header::from_bytes(&b"Server"[..], &b"swyh-rs tiny-http"[..]).unwrap());
     headers.push(Header::from_bytes(&b"icy-name"[..], &b"swyh-rs"[..]).unwrap());
     headers.push(Header::from_bytes(&b"Connection"[..], &b"close"[..]).unwrap());
-
-    /* don't accept range headers (Linn) until I know how to handle them
-    but don't send this header as the MPD player ignores the "none" value anyway and uses ranges
-    headers.push(Header::from_bytes(&b"Accept-Ranges"[..], &b"none"[..]).unwrap()); */
-
+    headers.push(Header::from_bytes(&b"Accept-Ranges"[..], &b"bytes"[..]).unwrap());
     headers
+}
+
+/// A parsed HTTP Range header of the form `bytes=<start>-[<end>]`.
+enum RangeSpec {
+    /// `bytes=<start>-` — open-ended; only `start` is known
+    From(u64),
+    /// `bytes=<start>-<end>` — bounded range; cannot be honoured on a live stream
+    Bounded,
+}
+
+/// Parse the first `Range: bytes=…` header present in `headers`, if any.
+fn parse_range_header(headers: &[tiny_http::Header]) -> Option<RangeSpec> {
+    let h = headers.iter().find(|h| h.field.equiv("range"))?;
+    let rest = h.value.as_str().strip_prefix("bytes=")?;
+    let (start_str, end_str) = rest.split_once('-')?;
+    let start = start_str.parse::<u64>().ok()?;
+    if end_str.is_empty() {
+        Some(RangeSpec::From(start))
+    } else {
+        Some(RangeSpec::Bounded)
+    }
+}
+
+/// Returns the byte length of the WAV/RF64 header for this context, or 0 for LPCM/FLAC.
+fn wav_header_size(ctx: &StreamingContext) -> usize {
+    match ctx.streaming_format {
+        StreamingFormat::Wav => 44,
+        StreamingFormat::Rf64 => 80,
+        _ => 0,
+    }
+}
+
+/// Build a `Content-Range` value for a 206 response starting at `start`.
+/// When `streamsize` is unknown (chunked), a large sentinel is used so the
+/// header remains RFC 7233 compliant (last-byte-pos must be a concrete value).
+fn content_range_value(ctx: &StreamingContext, start: usize) -> String {
+    let size = ctx.streamsize.unwrap_or(usize::MAX - 1);
+    format!("bytes {start}-{}/{size}", size.saturating_sub(1))
+}
+
+/// Respond 416 Range Not Satisfiable.
+fn range_not_satisfiable(streaming_ctx: &StreamingContext, rq: tiny_http::Request) {
+    ui_log(
+        LogCategory::Warning,
+        &fl!("srv-range-not-satisfiable", "addr" = &streaming_ctx.remote_addr),
+    );
+    let mut headers = get_std_headers();
+    let cr = match streaming_ctx.streamsize {
+        Some(size) => format!("bytes */{size}"),
+        None => "bytes */*".to_string(),
+    };
+    headers.push(Header::from_bytes(&b"Content-Range"[..], cr.as_bytes()).unwrap());
+    let response = Response::new(
+        tiny_http::StatusCode(416),
+        headers,
+        io::empty(),
+        Some(0),
+        None,
+    );
+    if let Err(e) = rq.respond(response) {
+        ui_log(
+            LogCategory::Error,
+            &fl!(
+                "srv-http-terminated",
+                "addr" = &streaming_ctx.remote_addr,
+                "error" = e.to_string()
+            ),
+        );
+    }
 }

--- a/src/server/streaming_server.rs
+++ b/src/server/streaming_server.rs
@@ -165,9 +165,16 @@ fn streaming_request(
         Some(RangeSpec::From(start)) => {
             let hdr_size = wav_header_size(streaming_ctx) as u64;
             if *start <= hdr_size {
+                // Start within the WAV/RF64 header (or byte 0 for any format): 206,
+                // trim that many header bytes from the front of the stream.
                 (206u16, *start as usize)
             } else {
-                return range_not_satisfiable(streaming_ctx, request);
+                // Start is past the header and into the audio data — we cannot seek
+                // into a live stream. Fall back to 200 and serve from the beginning,
+                // which matches the pre-range-support behaviour and keeps MPD happy
+                // (MPD probes with Range: bytes=<Content-Length>- after reading the
+                // WAV header to verify the announced size).
+                (200u16, 0usize)
             }
         }
     };
@@ -183,6 +190,7 @@ fn streaming_request(
     // get the dlna headers
     let mut headers = get_dlna_headers(streaming_ctx);
     if status_code == 206 {
+        headers.push(Header::from_bytes(&b"Accept-Ranges"[..], &b"bytes"[..]).unwrap());
         let cr = content_range_value(streaming_ctx, header_offset);
         headers.push(Header::from_bytes(&b"Content-Range"[..], cr.as_bytes()).unwrap());
     }
@@ -290,13 +298,14 @@ fn head_request(streaming_ctx: &StreamingContext, rq: tiny_http::Request, range:
             if *start <= hdr_size {
                 (206u16, *start as usize)
             } else {
-                return range_not_satisfiable(streaming_ctx, rq);
+                (200u16, 0usize)
             }
         }
     };
     // get the dlna headers
     let mut headers = get_dlna_headers(streaming_ctx);
     if status_code == 206 {
+        headers.push(Header::from_bytes(&b"Accept-Ranges"[..], &b"bytes"[..]).unwrap());
         let cr = content_range_value(streaming_ctx, header_offset);
         headers.push(Header::from_bytes(&b"Content-Range"[..], cr.as_bytes()).unwrap());
     }
@@ -408,7 +417,6 @@ fn get_std_headers() -> Vec<Header> {
     headers.push(Header::from_bytes(&b"Server"[..], &b"swyh-rs tiny-http"[..]).unwrap());
     headers.push(Header::from_bytes(&b"icy-name"[..], &b"swyh-rs"[..]).unwrap());
     headers.push(Header::from_bytes(&b"Connection"[..], &b"close"[..]).unwrap());
-    headers.push(Header::from_bytes(&b"Accept-Ranges"[..], &b"bytes"[..]).unwrap());
     headers
 }
 
@@ -457,6 +465,7 @@ fn range_not_satisfiable(streaming_ctx: &StreamingContext, rq: tiny_http::Reques
         &fl!("srv-range-not-satisfiable", "addr" = &streaming_ctx.remote_addr),
     );
     let mut headers = get_std_headers();
+    headers.push(Header::from_bytes(&b"Accept-Ranges"[..], &b"bytes"[..]).unwrap());
     let cr = match streaming_ctx.streamsize {
         Some(size) => format!("bytes */{size}"),
         None => "bytes */*".to_string(),


### PR DESCRIPTION
- streaming_server.rs
  - `get_std_headers()` — removed the old commented-out Accept-Ranges: none block; added Accept-Ranges: bytes unconditionally
  - Added `RangeSpec` enum (From(u64) / Bounded) for parsed Range headers
  - Added `parse_range_header()` — finds the first Range: bytes=… header via field.equiv("range") and parses it
  - Added `wav_header_size()` — returns 44/80/0 for WAV/RF64/other
  - Added `content_range_value()` — builds a RFC 7233-compliant Content-Range string; falls back to usize::MAX-1 sentinel when streamsize is None
  - Added `range_not_satisfiable()` — emits a 416 with Content-Range: bytes */<size>
  - run_server() dispatch — calls `parse_range_header()` once and passes the result into both handlers
  - `streaming_request()` — validates the range, returns 416 for bounded or out-of-header offsets, responds 206 + Content-Range for satisfiable ranges, passes header_offset to ChannelStream::new()
  - `head_request()` — same range logic, no body
 
- rwstream.rs
  - `ChannelStream::new()` — added header_offset: usize parameter; wav_hdr is drain-trimmed by that many bytes when non-zero, enabling the Range: bytes=44- (skip header) case

- Locale files
  - added `srv-range-not-satisfiable` key to all 8 language files (en-US, de-DE, es-ES, fr-FR, it-IT, ja-JP, nl-NL, zh-CN).

