### PR TITLE
downmix multichannel capture to stereo

### DIFF
--- a/locales/de-DE/main.ftl
+++ b/locales/de-DE/main.ftl
@@ -145,3 +145,4 @@ srv-bad-request = Unbekannte Anfrage '{ $url }' von '{ $addr }'
 srv-stream-terminated = =>HTTP-Streaming-Anfrage mit { $addr } beendet [{ $error }]
 
 srv-range-not-satisfiable = Range-Anfrage von { $addr } nicht erfüllbar, Antwort 416
+audio-downmix = Mische { $channels }-Kanal-Eingang zu Stereo für das Streaming (ITU-R BS.775)

--- a/locales/en-US/main.ftl
+++ b/locales/en-US/main.ftl
@@ -65,6 +65,7 @@ audio-capture-format = Audio capture sample format = { $fmt }
 err-capture-format-stream = Error capturing { $fmt } audio stream: { $error }
 err-capture-stream = Error { $error } capturing audio input stream
 audio-capture-receiving = Audio capture is now receiving samples.
+audio-downmix = Downmixing { $channels }-channel input to stereo for streaming (ITU-R BS.775)
 
 # FLAC encoder
 err-flac-already-running = Flac encoder already running!

--- a/locales/es-ES/main.ftl
+++ b/locales/es-ES/main.ftl
@@ -145,3 +145,4 @@ srv-bad-request = Solicitud no reconocida '{ $url }' desde '{ $addr }'
 srv-stream-terminated = =>Solicitud de streaming HTTP con { $addr } terminada [{ $error }]
 
 srv-range-not-satisfiable = Solicitud de rango de { $addr } no satisfacible, respondiendo 416
+audio-downmix = Mezclando entrada de { $channels } canales a estéreo para la transmisión (ITU-R BS.775)

--- a/locales/fr-FR/main.ftl
+++ b/locales/fr-FR/main.ftl
@@ -145,3 +145,4 @@ srv-bad-request = Requête non reconnue '{ $url }' depuis '{ $addr }'
 srv-stream-terminated = =>Requête de streaming HTTP avec { $addr } terminée [{ $error }]
 
 srv-range-not-satisfiable = Requête de plage de { $addr } non satisfaisable, réponse 416
+audio-downmix = Mixage de l'entrée à { $channels } canaux vers stéréo pour la diffusion (ITU-R BS.775)

--- a/locales/it-IT/main.ftl
+++ b/locales/it-IT/main.ftl
@@ -145,3 +145,4 @@ srv-bad-request = Richiesta non riconosciuta '{ $url }' da '{ $addr }'
 srv-stream-terminated = =>Richiesta di streaming HTTP con { $addr } terminata [{ $error }]
 
 srv-range-not-satisfiable = Richiesta di intervallo da { $addr } non soddisfacibile, risposta 416
+audio-downmix = Downmix dell'ingresso a { $channels } canali in stereo per lo streaming (ITU-R BS.775)

--- a/locales/ja-JP/main.ftl
+++ b/locales/ja-JP/main.ftl
@@ -145,3 +145,4 @@ srv-bad-request = '{ $addr }' からの認識できないリクエスト '{ $url
 srv-stream-terminated = =>{ $addr } との HTTP ストリーミングリクエストが終了しました [{ $error }]
 
 srv-range-not-satisfiable = { $addr } からの範囲リクエストは満たせません、416 を返します
+audio-downmix = { $channels } チャンネル入力をストリーミング用にステレオへダウンミックスしています (ITU-R BS.775)

--- a/locales/nl-NL/main.ftl
+++ b/locales/nl-NL/main.ftl
@@ -146,3 +146,4 @@ srv-bad-request = Onherkenbaar verzoek '{ $url }' van '{ $addr }'
 srv-stream-terminated = =>Http streaming verzoek met { $addr } beëindigd [{ $error }]
 
 srv-range-not-satisfiable = Bereikverzoek van { $addr } niet vervulbaar, antwoord 416
+audio-downmix = { $channels }-kanaals invoer wordt naar stereo gedownmixt voor streaming (ITU-R BS.775)

--- a/locales/zh-CN/main.ftl
+++ b/locales/zh-CN/main.ftl
@@ -145,3 +145,4 @@ srv-bad-request = 来自 '{ $addr }' 的无法识别的请求 '{ $url }'
 srv-stream-terminated = =>与 { $addr } 的 HTTP 流媒体请求已终止 [{ $error }]
 
 srv-range-not-satisfiable = 来自 { $addr } 的范围请求无法满足，响应 416
+audio-downmix = 将 { $channels } 声道输入下混为立体声进行流式传输 (ITU-R BS.775)

--- a/src/audio/audiodevices.rs
+++ b/src/audio/audiodevices.rs
@@ -5,7 +5,7 @@
 //! registered HTTP streaming clients.
 
 use crate::{
-    audio::rwstream::AudioSamples,
+    audio::{rwstream::AudioSamples, samples_conv::downmix_to_stereo},
     enums::messages::MessageType,
     fl,
     globals::statics::{RUN_RMS_MONITOR, get_clients, get_config, get_msgchannel},
@@ -306,10 +306,19 @@ pub fn capture_output_audio(
         &fl!("audio-default-config", "cfg" = format!("{audio_cfg:?}")),
     );
     let mut f32_samples: Vec<f32> = Vec::with_capacity(16384);
+    let mut stereo_samples: Vec<f32> = Vec::with_capacity(16384);
+    let channels = audio_cfg.channels();
+    if channels != 2 {
+        // The streaming pipeline is stereo-only, so non-stereo input is downmixed here.
+        ui_log(
+            LogCategory::Info,
+            &fl!("audio-downmix", "channels" = channels.to_string()),
+        );
+    }
     match audio_cfg.sample_format() {
         cpal::SampleFormat::F32 => match device.build_input_stream(
             audio_cfg.config(),
-            move |data, _: &_| wave_reader_f32(data, &rms_sender),
+            move |data, _: &_| wave_reader_f32(data, channels, &mut stereo_samples, &rms_sender),
             capture_err_fn,
             None,
         ) {
@@ -335,7 +344,15 @@ pub fn capture_output_audio(
         cpal::SampleFormat::I16 => {
             match device.build_input_stream(
                 audio_cfg.config(),
-                move |data, _: &_| wave_reader::<i16>(data, &mut f32_samples, &rms_sender),
+                move |data, _: &_| {
+                    wave_reader::<i16>(
+                        data,
+                        channels,
+                        &mut f32_samples,
+                        &mut stereo_samples,
+                        &rms_sender,
+                    )
+                },
                 capture_err_fn,
                 None,
             ) {
@@ -362,7 +379,15 @@ pub fn capture_output_audio(
         cpal::SampleFormat::U16 => {
             match device.build_input_stream(
                 audio_cfg.config(),
-                move |data, _: &_| wave_reader::<u16>(data, &mut f32_samples, &rms_sender),
+                move |data, _: &_| {
+                    wave_reader::<u16>(
+                        data,
+                        channels,
+                        &mut f32_samples,
+                        &mut stereo_samples,
+                        &rms_sender,
+                    )
+                },
                 capture_err_fn,
                 None,
             ) {
@@ -389,7 +414,15 @@ pub fn capture_output_audio(
         cpal::SampleFormat::I32 => {
             match device.build_input_stream(
                 audio_cfg.config(),
-                move |data, _: &_| wave_reader::<i32>(data, &mut f32_samples, &rms_sender),
+                move |data, _: &_| {
+                    wave_reader::<i32>(
+                        data,
+                        channels,
+                        &mut f32_samples,
+                        &mut stereo_samples,
+                        &rms_sender,
+                    )
+                },
                 capture_err_fn,
                 None,
             ) {
@@ -457,19 +490,40 @@ static ONFIRSTCALL: Once = Once::new();
 
 /// `wave_reader` - the generic captured audio input stream reader.
 /// Calls `distribute_samples` to feed all the threads needing them.
-fn wave_reader<T>(samples: &[T], f32_samples: &mut Vec<f32>, rms_sender: &Sender<AudioSamples>)
-where
+/// Non-stereo input is downmixed via [`downmix_to_stereo`] before distribution.
+fn wave_reader<T>(
+    samples: &[T],
+    channels: u16,
+    f32_samples: &mut Vec<f32>,
+    stereo_samples: &mut Vec<f32>,
+    rms_sender: &Sender<AudioSamples>,
+) where
     T: Sample + ToSample<f32>,
 {
     ONFIRSTCALL.call_once(capture_started);
     f32_samples.clear();
     f32_samples.extend(samples.iter().map(|x: &T| T::to_sample::<f32>(*x)));
-    distribute_samples(f32_samples, rms_sender);
+    if channels == 2 {
+        distribute_samples(f32_samples, rms_sender);
+    } else {
+        downmix_to_stereo(f32_samples, channels, stereo_samples);
+        distribute_samples(stereo_samples, rms_sender);
+    }
 }
 
 /// Specialized version of the generic `wave_reader` above for the "default" f32 case with Alsa/WasApi/PipeWire/Pulse.
 /// It bypasses the samples conversion iterator.
-fn wave_reader_f32(samples: &[f32], rms_sender: &Sender<AudioSamples>) {
+fn wave_reader_f32(
+    samples: &[f32],
+    channels: u16,
+    stereo_samples: &mut Vec<f32>,
+    rms_sender: &Sender<AudioSamples>,
+) {
     ONFIRSTCALL.call_once(capture_started);
-    distribute_samples(samples, rms_sender);
+    if channels == 2 {
+        distribute_samples(samples, rms_sender);
+    } else {
+        downmix_to_stereo(samples, channels, stereo_samples);
+        distribute_samples(stereo_samples, rms_sender);
+    }
 }

--- a/src/audio/samples_conv.rs
+++ b/src/audio/samples_conv.rs
@@ -90,6 +90,68 @@ pub(crate) fn i32_to_i24be(i32_array: &[i32; 4], buf: &mut [u8]) {
     buf[9..=11].copy_from_slice(&i32_array[3].to_be_bytes()[1..]);
 }
 
+/// Downmix coefficient for the center, side, and rear channels when folding multichannel
+/// audio into stereo. -3 dB ≈ 0.7071, the ITU-R BS.775 / ATSC A/52 stereo-downmix value.
+const DOWNMIX_ATTEN: f32 = std::f32::consts::FRAC_1_SQRT_2;
+
+/// Downmix interleaved multichannel f32 samples to interleaved stereo (L,R,L,R,...).
+///
+/// `channels` is the number of channels per frame in the input. The function assumes
+/// standard WAVE channel order (FL, FR, FC, LFE, BL, BR, SL, SR, ...). Channels beyond
+/// the 8th in WAVE order are summed equally into both L and R as a best-effort fallback.
+///
+/// Coefficients follow ITU-R BS.775 (also used by Blu-ray players and ffmpeg's default `-ac 2` downmix):
+///   L = FL + 0.7071·FC + 0.7071·BL + 0.7071·SL
+///   R = FR + 0.7071·FC + 0.7071·BR + 0.7071·SR
+/// LFE is dropped. The result is hard-clamped to ±1.0 to prevent integer overflow when
+/// the f32 samples are later converted to i16/i24 by `samples_to_i32`.
+///
+/// Special cases:
+/// - 1 channel: duplicated to L=R.
+/// - 2 channels: copied unchanged.
+///
+/// `stereo` is cleared and refilled, reusing its allocation across calls.
+pub(crate) fn downmix_to_stereo(samples: &[f32], channels: u16, stereo: &mut Vec<f32>) {
+    stereo.clear();
+    match channels {
+        0 | 2 => stereo.extend_from_slice(samples),
+        1 => {
+            stereo.reserve(samples.len() * 2);
+            for &s in samples {
+                stereo.push(s);
+                stereo.push(s);
+            }
+        }
+        n => {
+            let n = n as usize;
+            let frames = samples.len() / n;
+            stereo.reserve(frames * 2);
+            for frame in samples.chunks_exact(n) {
+                // Standard WAVE channel order: FL, FR, FC, LFE, BL, BR, SL, SR.
+                let fl = frame[0];
+                let fr = frame[1];
+                let fc = if n >= 3 { frame[2] } else { 0.0 };
+                // frame[3] is LFE — intentionally dropped.
+                let bl = if n >= 5 { frame[4] } else { 0.0 };
+                let br = if n >= 6 { frame[5] } else { 0.0 };
+                let sl = if n >= 7 { frame[6] } else { 0.0 };
+                let sr = if n >= 8 { frame[7] } else { 0.0 };
+                let mut l = fl + DOWNMIX_ATTEN * (fc + bl + sl);
+                let mut r = fr + DOWNMIX_ATTEN * (fc + br + sr);
+                // Any extra channels beyond standard 7.1 are mixed equally into both sides.
+                if n > 8 {
+                    for &extra in &frame[8..] {
+                        l += DOWNMIX_ATTEN * extra;
+                        r += DOWNMIX_ATTEN * extra;
+                    }
+                }
+                stereo.push(l.clamp(-1.0, 1.0));
+                stereo.push(r.clamp(-1.0, 1.0));
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,5 +164,74 @@ mod tests {
         assert_eq!(result[1], i16::MIN as i32);
         //assert_eq!(result[2], i16::MAX as i32 / 2);
         assert_eq!(result[3], 0i32);
+    }
+
+    #[test]
+    fn test_downmix_stereo_passthrough() {
+        let input = vec![0.1, -0.2, 0.3, -0.4];
+        let mut out = Vec::new();
+        downmix_to_stereo(&input, 2, &mut out);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn test_downmix_mono_to_stereo() {
+        let input = vec![0.5, -0.5, 0.25];
+        let mut out = Vec::new();
+        downmix_to_stereo(&input, 1, &mut out);
+        assert_eq!(out, vec![0.5, 0.5, -0.5, -0.5, 0.25, 0.25]);
+    }
+
+    #[test]
+    fn test_downmix_5_1_bs775() {
+        // One frame: FL=0.1, FR=0.2, FC=0.3, LFE=0.9 (dropped), BL=0.4, BR=0.5
+        let input = vec![0.1, 0.2, 0.3, 0.9, 0.4, 0.5];
+        let mut out = Vec::new();
+        downmix_to_stereo(&input, 6, &mut out);
+        assert_eq!(out.len(), 2);
+        let expected_l = 0.1 + DOWNMIX_ATTEN * (0.3 + 0.4);
+        let expected_r = 0.2 + DOWNMIX_ATTEN * (0.3 + 0.5);
+        assert!(
+            (out[0] - expected_l).abs() < 1e-6,
+            "L: {} vs {}",
+            out[0],
+            expected_l
+        );
+        assert!(
+            (out[1] - expected_r).abs() < 1e-6,
+            "R: {} vs {}",
+            out[1],
+            expected_r
+        );
+    }
+
+    #[test]
+    fn test_downmix_clamps_overflow() {
+        // 5.1 frame engineered so L = 1.0 + 0.707*1.0 + 0.707*1.0 ≈ 2.41 → clamps to 1.0
+        let input = vec![1.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        let mut out = Vec::new();
+        downmix_to_stereo(&input, 6, &mut out);
+        assert_eq!(out, vec![1.0, 1.0]);
+        // Negative side
+        let input = vec![-1.0, -1.0, -1.0, 0.0, -1.0, -1.0];
+        downmix_to_stereo(&input, 6, &mut out);
+        assert_eq!(out, vec![-1.0, -1.0]);
+    }
+
+    #[test]
+    fn test_downmix_frame_count() {
+        // 12 samples / 6 channels = 2 frames → 2 stereo frames = 4 samples out
+        let input = vec![0.0; 12];
+        let mut out = Vec::new();
+        downmix_to_stereo(&input, 6, &mut out);
+        assert_eq!(out.len(), 4);
+    }
+
+    #[test]
+    fn test_downmix_reuses_buffer() {
+        // Calling twice with different inputs must clear any prior content.
+        let mut out = vec![99.0, 99.0, 99.0];
+        downmix_to_stereo(&[0.0; 6], 6, &mut out);
+        assert_eq!(out, vec![0.0, 0.0]);
     }
 }

--- a/src/bin/swyh-rs-cli.rs
+++ b/src/bin/swyh-rs-cli.rs
@@ -314,7 +314,8 @@ fn main() -> Result<(), i32> {
     let wd = WavData {
         sample_format: audio_cfg.sample_format(),
         sample_rate: audio_cfg.sample_rate(),
-        channels: audio_cfg.channels(),
+        // post-downmix the stream is always 2-channel
+        channels: 2,
         default_sample_rate: default_rate,
     };
 

--- a/src/bin/swyh-rs.rs
+++ b/src/bin/swyh-rs.rs
@@ -227,7 +227,8 @@ fn main() {
     let wd = WavData {
         sample_format: audio_cfg.sample_format(),
         sample_rate: audio_cfg.sample_rate(),
-        channels: audio_cfg.channels(),
+        // post-downmix the stream is always 2-channel
+        channels: 2,
         default_sample_rate: default_rate,
     };
     debug!("wavdata: {:?}", wd);


### PR DESCRIPTION
## Problem

When the captured audio device delivers more than 2 channels (Logitech PRO X Wireless 7.1 in #56, Bose Companion 2 Series III with a 6-channel loopback mix, or any 5.1/7.1 device), `swyh-rs` writes the raw N-channel interleaved bytes into the stream while every encoder, WAV/RF64 header, LPCM Content-Type, UPnP ProtocolInfo, and DIDL nrAudioChannels is hardcoded to 2. The renderer reads bytes assuming stereo frames and plays the result at ~N/2× speed with heavy distortion.

## Proposed Solution

Downmix any non-stereo capture to interleaved stereo at the wave_reader / wave_reader_f32 seam, before samples reach the streaming clients. The rest of the pipeline (already stereo-only by design) stays self-consistent. Stereo input takes a zero-overhead fast path.

Coefficients follow [ITU-R BS.775-4](https://www.itu.int/dms_pubrec/itu-r/rec/bs/R-REC-BS.775-4-202212-I!!PDF-E.pdf) - the broadcast/Blu-ray standard, also used in ffmpeg's more advanced [`libswresample`](https://github.com/FFmpeg/FFmpeg/blob/master/libswresample/rematrix.c):
* `L = FL + 0.7071 × FC + 0.7071 × BL + 0.7071 × SL`
* `R = FR + 0.7071 × FC + 0.7071 × BR + 0.7071 × SR`

LFE is dropped, output is clamped to ±1.0 to avoid overflow in samples_to_i32. Mono input is duplicated to L=R.

`WavData.channels` is now 2 post-downmix so the RMS monitor reads correct L/R. The downmix output buffer is captured by the audio callback closure and reused across calls (matching the existing f32_samples pattern in the same module) - no per-callback allocation on the hot path.

- Fixes #56.

## Verification

- Successfully tested in practice with Bose Companion 2 (5.1 channels) and Sonos Play:1.
- New unit tests cover passthrough, mono duplication, BS.775 math, clamping, multi-frame iteration, and buffer reuse.