### PR TITLE
samples_conv: TPDF dither, round-to-nearest, ±1.0 clamp at all bit depths

### DIFF
--- a/src/audio/samples_conv.rs
+++ b/src/audio/samples_conv.rs
@@ -2,6 +2,15 @@
 //!
 //! Converts captured f32 audio samples to integer PCM formats (i16/i24, little/big endian)
 //! using SSE2 f32x4 SIMD registers via the `wide` crate.
+//!
+//! # Quantization quality
+//!
+//! The audio paths (FLAC and LPCM) use unbiased round-to-nearest quantization with explicit
+//! ±1.0 clamping at the f32 boundary, plus triangular-PDF (TPDF) dither at 16 bits to
+//! decorrelate quantization noise from the signal. This follows the AES recommendation
+//! (Lipshitz/Wannamaker/Vanderkooy 1992, JAES Vol 40 No 5). At 24 bits the residual
+//! quantization noise floor (~−141 dBFS) is below the threshold of audibility on any
+//! consumer playback chain, so dither is skipped.
 
 use wide::f32x4;
 
@@ -11,10 +20,46 @@ use crate::enums::streaming::BitDepth;
 const F32_TO_I32: f32 = (i32::MAX as f32) + 1.0;
 /// XMM register constant
 static F32_TO_I32_SIMD: f32x4 = f32x4::splat(F32_TO_I32);
+/// f32 clamp rails — applied before quantization so out-of-range samples (which WASAPI
+/// shared-mode mixing can produce on intersample peaks) clip to full scale instead of
+/// relying on `wide`'s post-conversion saturation. Makes the stereo passthrough path
+/// behave identically to the downmix path, which already clamps.
+static CLAMP_HI: f32x4 = f32x4::splat(1.0);
+static CLAMP_LO: f32x4 = f32x4::splat(-1.0);
+
+/// One LSB at 16-bit, expressed in the post-multiply (i32-scaled) f32 domain.
+/// `F32_TO_I32 / 2^15 == 2^31 / 2^15 == 2^16 == 65536.0`.
+const LSB_AT_16BIT_POST_MULT: f32 = 65536.0;
+
+/// Half-LSB nudge at 16-bit, applied in the post-multiply f32 domain before
+/// `round_int + arithmetic shift`. Without this, the composition `round_int(x) >> 16`
+/// is floor-after-round (the shift floors toward −∞), introducing a constant
+/// −0.5 LSB DC bias regardless of sign — defeating the whole purpose of
+/// round-to-nearest. Adding 32768 before the shift converts floor-shift into
+/// round-to-nearest-shift.
+static HALF_LSB_16_SIMD: f32x4 = f32x4::splat(32_768.0);
+/// Half-LSB nudge at 24-bit (= 2^7). Same logic as the 16-bit case; the bias would
+/// be ~−178 dBFS so it's inaudible, but applying the nudge anyway keeps both code
+/// paths unbiased and the math symmetric.
+static HALF_LSB_24_SIMD: f32x4 = f32x4::splat(128.0);
+
+/// Generate one f32x4 of triangular-PDF (TPDF) dither for 16-bit quantization, in the
+/// post-multiply f32 domain. Each lane is `(u1 − u2) · LSB`, with u1, u2 ∼ U[0, 1).
+/// Peak amplitude ±1 LSB, mean 0, triangular density on (−1, 1) LSB. Reads from
+/// `fastrand`'s per-thread RNG.
+#[inline(always)]
+fn tpdf_dither_lanes_16_threadlocal() -> f32x4 {
+    f32x4::new([
+        (fastrand::f32() - fastrand::f32()) * LSB_AT_16BIT_POST_MULT,
+        (fastrand::f32() - fastrand::f32()) * LSB_AT_16BIT_POST_MULT,
+        (fastrand::f32() - fastrand::f32()) * LSB_AT_16BIT_POST_MULT,
+        (fastrand::f32() - fastrand::f32()) * LSB_AT_16BIT_POST_MULT,
+    ])
+}
 
 /// convert f32 samples to i32 for flac encoding
 /// but scaled to i16 or i24 according to shift (8 or 16)
-/// using SIMD SSE xmm registers (with the wide crate)
+/// using SIMD SSE xmm registers (with the wide crate).
 pub(crate) fn samples_to_i32(f32_samples: &[f32], i32_samples: &mut Vec<i32>, bd: BitDepth) {
     debug_assert!(
         f32_samples.len() & 1 == 0,
@@ -42,11 +87,31 @@ pub(crate) fn f32_chunk_to_i32(bd: BitDepth, samples: &[f32; 4]) -> [i32; 4] {
     f32_to_i32(bd, f32x4::new(*samples))
 }
 
-/// convert 4 f32 samples in an f32x4 to 4 i32 samples (using SIMD)
+/// Convert 4 f32 samples in an f32x4 to 4 i32 samples (using SIMD), scaled to the
+/// requested bit depth. Steps: clamp ±1.0 → multiply by 2³¹ → add TPDF dither (16-bit
+/// only) → round-to-nearest → arithmetic right-shift.
+///
+/// At 24 bits the dither is skipped: the residual quantization noise floor at 24 bits
+/// (~−141 dBFS) is below audibility on any consumer playback chain, so dither would
+/// add only noise without perceptual benefit.
+///
+/// `round_int` saturates out-of-range inputs and maps NaN to 0 (per the `wide` crate's
+/// documented contract — it wraps the underlying SSE `CVTPS2DQ` to give defined
+/// behaviour). Defence in depth against any path that bypasses the clamp.
 #[inline(always)]
 pub(crate) fn f32_to_i32(bd: BitDepth, f32_simd: f32x4) -> [i32; 4] {
-    let fchunk_i32 = f32_simd * F32_TO_I32_SIMD;
-    let s4i = fchunk_i32.trunc_int() >> bd.shift_value();
+    let clamped = f32_simd.fast_min(CLAMP_HI).fast_max(CLAMP_LO);
+    let scaled = clamped * F32_TO_I32_SIMD;
+    // Apply TPDF dither at 16 bits (skipped at 24), then add the half-LSB nudge that
+    // converts the subsequent `round_int + arithmetic-shift` into true round-to-nearest.
+    // Without the nudge, `>> N` floors toward −∞ and re-introduces a constant −0.5 LSB
+    // DC bias even though `round_int` itself rounds correctly.
+    let pre_quant = if bd == BitDepth::Bits16 {
+        scaled + tpdf_dither_lanes_16_threadlocal() + HALF_LSB_16_SIMD
+    } else {
+        scaled + HALF_LSB_24_SIMD
+    };
+    let s4i = pre_quant.round_int() >> bd.shift_value();
     s4i.to_array()
 }
 
@@ -164,14 +229,187 @@ pub(crate) fn downmix_to_stereo(samples: &[f32], channels: u16, stereo: &mut Vec
 mod tests {
     use super::*;
 
+    /// Test-only seeded variant of the TPDF dither generator. The production code
+    /// uses `tpdf_dither_lanes_16_threadlocal` (which reads `fastrand`'s thread-local
+    /// state); for deterministic tests we want to control the seed directly.
+    fn tpdf_dither_lanes_16_seeded(rng: &mut fastrand::Rng) -> f32x4 {
+        f32x4::new([
+            (rng.f32() - rng.f32()) * LSB_AT_16BIT_POST_MULT,
+            (rng.f32() - rng.f32()) * LSB_AT_16BIT_POST_MULT,
+            (rng.f32() - rng.f32()) * LSB_AT_16BIT_POST_MULT,
+            (rng.f32() - rng.f32()) * LSB_AT_16BIT_POST_MULT,
+        ])
+    }
+
     #[test]
     fn test_f32_to_i32_i16_range() {
+        // 16-bit conversion is dithered, so output is a random variable within
+        // ±1 LSB of the deterministic round-to-nearest value. We assert the
+        // tolerance band rather than exact equality.
         let arr = f32x4::new([1.0, -1.0, 0.5, 0.0]);
         let result = f32_to_i32(BitDepth::Bits16, arr);
-        assert_eq!(result[0], i16::MAX as i32);
-        assert_eq!(result[1], i16::MIN as i32);
-        //assert_eq!(result[2], i16::MAX as i32 / 2);
-        assert_eq!(result[3], 0i32);
+        // For input 1.0: clamp leaves 1.0, multiply gives ≈ 2^31 (in f32). Adding
+        // any dither in (−65536, +65536) plus the 32768 nudge then arithmetic-shifting
+        // by 16 always lands at 32767 (positive dither saturates round_int to i32::MAX
+        // → 32767; negative dither gives (2^31 − 32768) >> 16 = 32767). Symmetric for
+        // −1.0. So [0]/[1] are deterministically i16::MAX / i16::MIN here; the ±1 LSB
+        // band is only meaningfully exercised at [3] (input 0.0).
+        assert!((result[0] - i16::MAX as i32).abs() <= 1);
+        assert!((result[1] - i16::MIN as i32).abs() <= 1);
+        // 0.5 · 2^31 = 2^30; (2^30) >> 16 = 2^14 = 16384. With TPDF dither at
+        // ±1 LSB the result is in {16383, 16384, 16385}.
+        assert!((result[2] - (1 << 14)).abs() <= 1);
+        assert!(result[3].abs() <= 1);
+    }
+
+    #[test]
+    fn test_f32_to_i32_clamps_above_one() {
+        // WASAPI shared-mode mixing can produce intersample peaks > 1.0. The clamp
+        // must map these to full-scale, not let them wrap or drift via SIMD saturation.
+        // At 24-bit (no dither) the result is exact; at 16-bit dither could pull it
+        // 1 LSB below i16::MAX so we assert the ±1 LSB band there.
+        let arr = f32x4::new([1.05, 1.5, 100.0, f32::INFINITY]);
+        let result_24 = f32_to_i32(BitDepth::Bits24, arr);
+        for v in result_24 {
+            assert_eq!(v, 0x7F_FFFF);
+        }
+        let result_16 = f32_to_i32(BitDepth::Bits16, arr);
+        for v in result_16 {
+            assert!((v - i16::MAX as i32).abs() <= 1);
+        }
+    }
+
+    #[test]
+    fn test_f32_to_i32_clamps_below_neg_one() {
+        let arr = f32x4::new([-1.05, -1.5, -100.0, f32::NEG_INFINITY]);
+        let result_24 = f32_to_i32(BitDepth::Bits24, arr);
+        for v in result_24 {
+            assert_eq!(v, -0x80_0000);
+        }
+        let result_16 = f32_to_i32(BitDepth::Bits16, arr);
+        for v in result_16 {
+            assert!((v - i16::MIN as i32).abs() <= 1);
+        }
+    }
+
+    #[test]
+    fn test_f32_to_i32_handles_nan() {
+        // NaN cannot occur in practice (WASAPI does not produce NaN samples), but the
+        // pipeline must not panic if it ever did. On x86, MINPS/MAXPS — which back
+        // `fast_min`/`fast_max` — return the non-NaN operand when one input is NaN, so
+        // our ±1.0 clamps coerce any NaN to a finite rail before quantization. The
+        // exact rail it lands on is platform-/operand-order-dependent; we only assert
+        // the output stays inside the legal i16 range and is finite.
+        let arr = f32x4::new([f32::NAN, 0.0, 0.0, 0.0]);
+        let result = f32_to_i32(BitDepth::Bits16, arr);
+        assert!(
+            result[0] >= i16::MIN as i32 && result[0] <= i16::MAX as i32,
+            "NaN escaped clamp: {}",
+            result[0]
+        );
+    }
+
+    #[test]
+    fn test_f32_to_i32_24bit_unchanged() {
+        // 24-bit path is undithered and deterministic — known reference values must
+        // continue to match exactly. This test guards against accidental dithering
+        // creeping into the 24-bit path in the future.
+        let arr = f32x4::new([1.0, -1.0, 0.5, 0.0]);
+        let result = f32_to_i32(BitDepth::Bits24, arr);
+        // 1.0 · 2^31 saturates to i32::MAX, then >> 8 = 0x7FFFFF
+        assert_eq!(result[0], 0x7F_FFFF);
+        // -1.0 · 2^31 = -2^31, >> 8 = -0x80_0000 (sign-extended arithmetic shift)
+        assert_eq!(result[1], -0x80_0000);
+        // 0.5 · 2^31 = 2^30, >> 8 = 2^22
+        assert_eq!(result[2], 1 << 22);
+        assert_eq!(result[3], 0);
+    }
+
+    #[test]
+    fn test_tpdf_dither_zero_mean() {
+        // 10 000 dither samples at 16-bit should have mean within ±0.1 LSB of zero.
+        // (Standard error of mean for U(-1,1)+U(-1,1) over N samples is √(2/3 N) LSB,
+        // ≈ 0.0082 LSB at N=10 000 — 0.1 LSB is a comfortable bound.)
+        let mut rng = fastrand::Rng::with_seed(0xDEAD_BEEF);
+        let mut sum = 0.0f64;
+        let mut count = 0u32;
+        for _ in 0..2500 {
+            let lanes = tpdf_dither_lanes_16_seeded(&mut rng).to_array();
+            for v in lanes {
+                sum += v as f64;
+                count += 1;
+            }
+        }
+        let mean_lsb = (sum / count as f64) / LSB_AT_16BIT_POST_MULT as f64;
+        assert!(
+            mean_lsb.abs() < 0.1,
+            "TPDF dither mean drifted: {mean_lsb} LSB"
+        );
+    }
+
+    #[test]
+    fn test_tpdf_dither_peak_within_two_lsb() {
+        // TPDF on (u1 - u2) has support (-1, 1) LSB. Allow a small epsilon for
+        // floating-point boundary effects.
+        let mut rng = fastrand::Rng::with_seed(42);
+        for _ in 0..2500 {
+            let lanes = tpdf_dither_lanes_16_seeded(&mut rng).to_array();
+            for v in lanes {
+                let abs_lsb = v.abs() / LSB_AT_16BIT_POST_MULT;
+                assert!(
+                    abs_lsb < 1.0 + 1e-6,
+                    "TPDF dither out of range: {abs_lsb} LSB"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_tpdf_dither_seeded_deterministic() {
+        // Regression guard: with a fixed seed the dither sequence must be reproducible.
+        let mut rng_a = fastrand::Rng::with_seed(123);
+        let mut rng_b = fastrand::Rng::with_seed(123);
+        for _ in 0..16 {
+            let a = tpdf_dither_lanes_16_seeded(&mut rng_a).to_array();
+            let b = tpdf_dither_lanes_16_seeded(&mut rng_b).to_array();
+            assert_eq!(a, b);
+        }
+    }
+
+    #[test]
+    fn test_f32_to_i32_16bit_dither_bounded_and_unbiased() {
+        // The 16-bit dithered output is a random variable. Two checks:
+        //  (a) The spread across many trials must be ≤ 3 LSBs — TPDF dither has open
+        //      support (-1, 1) LSB, and after round_int the output lands in one of at
+        //      most 3 adjacent integer values.
+        //  (b) The mean across many trials must be close to the analytical
+        //      round-to-nearest value `round(f · 2^15)`, because TPDF is zero-mean.
+        //      With N=1000 the standard error of the mean is well below 0.1 LSB.
+        let inputs = [0.1f32, -0.3, 0.5, -0.7];
+        let arr = f32x4::new(inputs);
+        let mut lane_samples: [Vec<i32>; 4] = Default::default();
+        for _ in 0..1000 {
+            let r = f32_to_i32(BitDepth::Bits16, arr);
+            for i in 0..4 {
+                lane_samples[i].push(r[i]);
+            }
+        }
+        for i in 0..4 {
+            let max = *lane_samples[i].iter().max().unwrap();
+            let min = *lane_samples[i].iter().min().unwrap();
+            assert!(
+                max - min <= 3,
+                "lane {i} spread too large: {min}..{max} (range {})",
+                max - min
+            );
+            let mean: f64 = lane_samples[i].iter().map(|&v| v as f64).sum::<f64>()
+                / lane_samples[i].len() as f64;
+            let ref_val = (inputs[i] * 32_768.0_f32).round() as i32;
+            assert!(
+                (mean - ref_val as f64).abs() < 0.5,
+                "lane {i} mean {mean} drifted from analytical reference {ref_val}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Brings the f32 → integer PCM conversion path in `samples_conv.rs` up to standard professional quantization practice. Three small, related improvements applied uniformly to both 16-bit and 24-bit paths; 16-bit additionally gets TPDF dither.

## Changes

1. **Unbiased round-to-nearest** instead of round-toward-zero — replaces `f32x4::trunc_int()` with `f32x4::round_int()` plus an explicit half-LSB float-domain nudge (`+ 32768.0` at 16-bit, `+ 128.0` at 24-bit) before the arithmetic right-shift. The nudge is necessary because `round_int(x) >> N` alone is floor-after-round: the arithmetic shift floors toward −∞ and would re-introduce the same −0.5 LSB DC bias the round was meant to remove. With the nudge, the composition becomes true round-to-nearest. Lets the previously-commented-out `0.5` assertion in `test_f32_to_i32_i16_range` be reinstated.

2. **Explicit ±1.0 clamp** at the f32 boundary, before the multiply by 2³¹. Makes the stereo passthrough path behave identically to the multichannel downmix path (which already clamped). Intersample peaks coming out of the WASAPI shared-mode mixer now clip deterministically at full scale instead of relying on `wide`'s post-conversion saturation. The clamp uses `fast_min`/`fast_max`, which lower to x86 MINPS/MAXPS — these return the second operand on NaN, so any NaN that ever reached this path would collapse to a finite ±1.0 rail before quantization.

3. **TPDF dither at 16 bits** — adds triangular-PDF dither (sum of two uniform draws, peak ±1 LSB) before quantization on the 16-bit path. Decorrelates quantization noise from the signal, the AES recommendation since Lipshitz/Wannamaker/Vanderkooy 1992 (JAES Vol 40 No 5). 24-bit path skips dither (noise floor ~−141 dBFS, below audibility). The silence/noise filler in `flacstream::fill_noise_buffer` also goes through the unified `f32_to_i32`; the extra RNG cost during silence is trivial and the dithered output is indistinguishable from the random source it replaces.

## Audible effect

**16-bit (the configuration default)** — modest but real audible improvement: cleaner-sounding fade-outs, reverb tails, and quiet passages on dynamic material (classical, jazz, ambient); deterministic clipping behaviour on hot masters across all channel configurations.

**24-bit** — *not* bit-identical to before. The round-to-nearest change differs from the old truncate-toward-zero on roughly **20.8% of samples** on uniformly random input (verified empirically over 1 M samples), always by **exactly ±1 LSB at 24-bit (≈ −138 dBFS)**, with a small positive mean (+0.21 LSB) reflecting the half-up tie-breaking direction of the nudge. This is the same DC-bias correction as at 16-bit — strictly an improvement (less bias toward zero) but technically a change. Inaudible: 1 LSB at 24-bit is below the noise floor of any consumer DAC and well below the threshold of human hearing. Out-of-range inputs (intersample peaks) saturate identically to before (verified).

Performance: a handful of extra SIMD instructions per 4-sample chunk (`fast_min` / `fast_max` / `round_int` / one f32 add at both depths, plus eight `fastrand::f32()` calls per 4-sample chunk at 16-bit only — two per lane × four lanes for the `(u1 − u2)` triangular construction). Roughly 1 μs per millisecond of audio at 48 kHz stereo.

## API impact

None. Public functions (`samples_to_i32`, `f32_chunk_to_i32`, `f32_to_i32`) keep their signatures. New crate-private TPDF generator (`tpdf_dither_lanes_16_threadlocal`) added.

## Tests

20 tests in `samples_conv` (was 12), all passing. New coverage:

- `test_f32_to_i32_clamps_above_one` / `_below_neg_one` — out-of-range f32 maps to full scale.
- `test_f32_to_i32_handles_nan` — NaN does not panic and stays in i16 range (relies on x86 MINPS/MAXPS NaN-handling: the ±1.0 clamp coerces NaN to a finite rail before quantization).
- `test_f32_to_i32_24bit_unchanged` — 24-bit reference values unchanged; guards against accidental dithering creeping into the 24-bit path.
- `test_f32_to_i32_16bit_dither_bounded_and_unbiased` — this test catches both broken dither and broken rounding (it failed before the half-LSB nudge was added).
- `test_tpdf_dither_zero_mean` — statistical guarantee that dither does not add a DC offset (|mean| < 0.1 LSB over 10 000 samples).
- `test_tpdf_dither_peak_within_two_lsb` — TPDF support is bounded to ±1 LSB.
- `test_tpdf_dither_seeded_deterministic` — regression guard with fixed seed.

The previously-commented-out `0.5` assertion in `test_f32_to_i32_i16_range` is now uncommented and passes (with a corrected expected value of `1 << 14`, not `i16::MAX as i32 / 2` — the original RHS was off by one due to integer division truncating).

`cargo test --lib`: 42 passed, 0 failed. `cargo clippy --all-targets --all-features`: clean. `cargo build`: clean.

## Dependencies

No new dependencies. `fastrand` is already in `Cargo.toml` (used by `flacstream`).

## References

- Lipshitz, Wannamaker & Vanderkooy, ["Quantization and Dither: A Theoretical Survey"](https://www.aes.org/e-lib/browse.cfm?elib=7047), JAES Vol 40 No 5, May 1992.
- FFmpeg [`libswresample` resampler options](https://ffmpeg.org/ffmpeg-resampler.html#Resampler-Options) including `dither_method` (TPDF default).
- sox [`dither` effect](https://linux.die.net/man/1/sox) (TPDF / noise-shaped TPDF) — see the `dither` effect in the man page.
- `wide` crate [`f32x4::round_int`](https://docs.rs/wide/latest/wide/struct.f32x4.html#method.round_int) — saturates out-of-range, maps NaN to 0.
- Intel Intrinsics Guide: [`_mm_min_ps` / `_mm_max_ps`](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_min_ps) (NaN handling: second operand returned).
- Intel Intrinsics Guide: [`_mm_cvtps_epi32`](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtps_epi32) (CVTPS2DQ semantics; `wide` wraps this and additionally maps NaN to 0).
