### PR TITLE
Add explicit HTTP timeouts to the renderer discovery/control agent

### DIFF
--- a/src/bin/swyh-rs-cli.rs
+++ b/src/bin/swyh-rs-cli.rs
@@ -41,7 +41,7 @@ use swyh_rs::{
         APP_DATE, APP_VERSION, ONE_MINUTE, SERVER_PORT, THREAD_STACK, get_clients, get_config_mut,
         get_msgchannel, get_renderers, get_renderers_mut,
     },
-    renderers::rendercontrol::{Renderer, StreamInfo, WavData, discover},
+    renderers::rendercontrol::{Renderer, StreamInfo, WavData, discover, new_agent},
     server::streaming_server::run_server,
     utils::{
         bincommon::run_silence_injector,
@@ -840,7 +840,7 @@ fn shutdown_ctrlc(serve_only: bool, player: Option<&Renderer>, playing: Vec<Rend
 /// and forward new ones to the main thread via `ssdp_tx`
 fn run_ssdp_updater(ssdp_tx: &Sender<MessageType>, ssdp_interval_mins: f64) {
     let mut rmap: HashMap<String, Renderer> = HashMap::new();
-    let agent = ureq::agent();
+    let agent = new_agent();
     loop {
         let renderers = discover(&agent, &rmap).unwrap_or_default();
         for r in &renderers {

--- a/src/renderers/rendercontrol.rs
+++ b/src/renderers/rendercontrol.rs
@@ -1019,6 +1019,27 @@ MX: 3\r\n\r\n";
     Some(usable)
 }
 
+/// Build the shared HTTP [`ureq::Agent`] used for renderer discovery and control.
+///
+/// `ureq`'s default configuration leaves every request timeout unset (`connect`,
+/// `recv_response` and `global` are all `None`), so a renderer that accepts the
+/// TCP connection but never sends back a complete response would block the
+/// request forever. Because [`discover`] waits for all per-renderer fetches to
+/// finish before returning, a single such renderer would stall the whole
+/// discovery cycle; and since the renderer control calls (`play`/`stop_play`/
+/// `set_volume`) reuse this same agent, an unresponsive renderer could likewise
+/// block their caller. Setting explicit timeouts bounds every request, so a
+/// stalled renderer is skipped for that cycle and retried on the next one.
+#[must_use]
+pub fn new_agent() -> ureq::Agent {
+    ureq::Agent::new_with_config(
+        ureq::Agent::config_builder()
+            .timeout_global(Some(Duration::from_secs(10)))
+            .timeout_connect(Some(Duration::from_secs(4)))
+            .build(),
+    )
+}
+
 //
 // SSDP UPNP service discovery
 //
@@ -1361,5 +1382,45 @@ Location: http://192.168.1.181:33065/dev/e8dbf26b-de8f-4c96-0000-0000002ea642/de
         assert!(!parsed.location.is_empty());
         assert!(parsed.is_av);
         assert!(!parsed.is_oh);
+    }
+
+    #[test]
+    fn new_agent_configures_request_timeouts() {
+        // Fast always-on guard: the shared agent must carry explicit timeouts
+        // so a renderer that accepts a connection but never responds can't block
+        // a request — and therefore the whole discovery cycle — indefinitely.
+        // This asserts the timeouts are *set*; `unresponsive_renderer_request_times_out`
+        // (ignored, ~10s) proves they actually *fire* end-to-end.
+        let timeouts = new_agent().config().timeouts();
+        assert_eq!(timeouts.global, Some(Duration::from_secs(10)));
+        assert_eq!(timeouts.connect, Some(Duration::from_secs(4)));
+    }
+
+    #[test]
+    #[ignore = "~10s: drives the real global request timeout against a stalled peer"]
+    fn unresponsive_renderer_request_times_out() {
+        use std::io::Read;
+        use std::net::TcpListener;
+        use std::time::Instant;
+        // A stand-in "renderer" that accepts the TCP connection, reads the
+        // request, then holds the socket open forever without ever replying —
+        // the exact failure mode that used to hang discovery indefinitely.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let mut s = stream.unwrap();
+                let _ = s.read(&mut [0u8; 1024]);
+                std::thread::sleep(Duration::from_secs(3600));
+            }
+        });
+        let start = Instant::now();
+        let result = new_agent().get(format!("http://{addr}/desc.xml")).call();
+        let elapsed = start.elapsed();
+        assert!(result.is_err(), "expected a timeout error, got Ok");
+        assert!(
+            elapsed < Duration::from_secs(20),
+            "request did not time out; it hung for {elapsed:?}"
+        );
     }
 }

--- a/src/utils/extra_threads.rs
+++ b/src/utils/extra_threads.rs
@@ -17,7 +17,7 @@ use crate::{
     audio::rwstream::AudioSamples,
     enums::messages::MessageType,
     globals::statics::{ONE_MINUTE, RUN_RMS_MONITOR},
-    renderers::rendercontrol::{Renderer, WavData, discover},
+    renderers::rendercontrol::{Renderer, WavData, discover, new_agent},
 };
 
 /// run the `ssdp_updater` - thread that periodically runs ssdp discovery
@@ -29,7 +29,7 @@ pub fn run_ssdp_updater(
     ssdp_interval_mins: f64,
     kick_rx: Receiver<()>,
 ) {
-    let agent = ureq::agent();
+    let agent = new_agent();
     // the hashmap used to detect new renderers
     let mut rmap: HashMap<String, Renderer> = HashMap::new();
     let mut first_time = true;


### PR DESCRIPTION
## Summary

The background SSDP updater rediscovers UPnP/DLNA renderers on a fixed interval, and for each one it fetches the device-description XML and reads the current volume over HTTP. These requests use a `ureq` agent created with `ureq::agent()`, whose default configuration sets **no request timeout of any kind** (`connect`, `recv_response`, and `global` are all `None`).

Discovery fetches every renderer concurrently and then waits for all of those fetches to finish before returning. If a single renderer accepts the TCP connection but never sends back a complete HTTP response, that request blocks forever — and because the updater only starts its next cycle after the current one returns, the whole discovery loop stalls permanently. The renderer list silently freezes and never recovers until the app is restarted. Audio that is already streaming keeps playing, but newly added, renamed, or reconnected renderers stop appearing.

The same agent is reused by the renderer control calls (`play` / `stop_play` / `set_volume`), which the GUI invokes on the main thread, so an unresponsive renderer could also block those actions.

## How this happens in practice

No unusual conditions are required — a renderer that goes away ungracefully mid-request is enough:

- A speaker is powered off, unplugged, or reboots (e.g. a firmware update) exactly while its description or volume is being fetched.
- A renderer drops off Wi-Fi or roams between access points and leaves a half-open TCP connection behind.
- A renderer that is simply slow or flaky about answering — the socket is open, but a complete response never arrives.

In each case the connection is established (so nothing fails fast), the response never comes, and the request hangs indefinitely.

## Fix

Introduce a single `new_agent()` constructor for the discovery/control HTTP agent that sets explicit timeouts (`timeout_global = 10s`, `timeout_connect = 4s`) and use it in both the GUI and CLI SSDP updaters. A stalled request now fails after the timeout instead of blocking; the affected renderer is skipped for that cycle and picked up again on the next discovery run.

## Notes

- Timed-out requests flow through the existing error paths unchanged: a failed description fetch skips that renderer, and a failed volume read falls back to "no volume control", which the UI already handles. No new error handling was added.
- 10s is far above normal LAN control-request latency (single-digit milliseconds), so healthy renderers are unaffected; the ceiling only bounds the worst case.
- Renderer control (`play` / `stop_play` / `set_volume`) still runs on the GUI thread, so an unresponsive renderer can now briefly stall the UI for up to the timeout rather than indefinitely. Moving that I/O to a worker thread is a reasonable follow-up, tracked separately.

## Testing

- `cargo test --features gui,cli` runs `new_agent_configures_request_timeouts`, which asserts the shared agent is built with the expected timeouts.
- The end-to-end behavior is covered by an ignored test that stands up a local TCP listener which accepts the connection and never replies, then asserts the request returns an error instead of hanging. Because it waits for the real ~10s timeout, it is excluded from the default run; execute it explicitly with:
```bash
$ cargo test --features gui,cli -- --ignored unresponsive_renderer_request_times_out
```
With the previous `ureq::agent()` default (no timeouts) this test never returns; with the fix it completes in ~10s.