### PR TITLE
refactor: add Configuration::stream_size_for/set_stream_size_for

### DIFF
--- a/src/bin/swyh-rs-cli.rs
+++ b/src/bin/swyh-rs-cli.rs
@@ -29,13 +29,7 @@ use swyh_rs::{
     audio::audiodevices::{
         Device, capture_output_audio, get_default_audio_output_device, get_output_audio_devices,
     },
-    enums::{
-        messages::MessageType,
-        streaming::{
-            StreamingFormat::{Flac, Lpcm, Rf64, Wav},
-            StreamingState,
-        },
-    },
+    enums::{messages::MessageType, streaming::StreamingState},
     fl,
     globals::statics::{
         APP_DATE, APP_VERSION, ONE_MINUTE, SERVER_PORT, THREAD_STACK, get_clients, get_config_mut,
@@ -680,15 +674,10 @@ fn apply_streaming_args(args: &Args, config: &mut Configuration) {
     if args.bits_per_sample.is_some() {
         config.bits_per_sample = args.bits_per_sample;
     }
-    if let Some(ref sf) = args.streaming_format {
+    if let Some(sf) = args.streaming_format {
         config.streaming_format = args.streaming_format;
-        if args.stream_size.is_some() {
-            match sf {
-                Lpcm => config.lpcm_stream_size = args.stream_size,
-                Wav => config.wav_stream_size = args.stream_size,
-                Flac => config.flac_stream_size = args.stream_size,
-                Rf64 => config.rf64_stream_size = args.stream_size,
-            }
+        if let Some(size) = args.stream_size {
+            config.set_stream_size_for(sf, size);
         }
     }
     if args.upfront_buffer.is_some() {

--- a/src/enums/streaming.rs
+++ b/src/enums/streaming.rs
@@ -262,16 +262,10 @@ impl StreamingContext {
         let bits_per_sample = params
             .bd
             .unwrap_or_else(|| BitDepth::from(cfg.bits_per_sample.unwrap_or(16)));
-        let (streamsize, chunksize) =
-            params
-                .ss
-                .map(|ss| ss.values())
-                .unwrap_or_else(|| match streaming_format {
-                    StreamingFormat::Lpcm => cfg.lpcm_stream_size.unwrap().values(),
-                    StreamingFormat::Wav => cfg.wav_stream_size.unwrap().values(),
-                    StreamingFormat::Rf64 => cfg.rf64_stream_size.unwrap().values(),
-                    StreamingFormat::Flac => cfg.flac_stream_size.unwrap().values(),
-                });
+        let (streamsize, chunksize) = params
+            .ss
+            .map(|ss| ss.values())
+            .unwrap_or_else(|| cfg.stream_size_for(streaming_format).unwrap().values());
 
         StreamingContext {
             sample_rate: wd.sample_rate,

--- a/src/ui/mainform.rs
+++ b/src/ui/mainform.rs
@@ -330,16 +330,13 @@ impl MainForm {
         );
 
         // streaming content length / chunking
-        let streamsize = if let Some(fmt) = config.streaming_format {
-            match fmt {
-                StreamingFormat::Lpcm => config.lpcm_stream_size.unwrap_or(StreamSize::NoneChunked),
-                StreamingFormat::Wav => config.wav_stream_size.unwrap_or(StreamSize::NoneChunked),
-                StreamingFormat::Rf64 => config.rf64_stream_size.unwrap_or(StreamSize::NoneChunked),
-                StreamingFormat::Flac => config.flac_stream_size.unwrap_or(StreamSize::NoneChunked),
-            }
-        } else {
-            StreamSize::U64maxNotChunked
-        };
+        let streamsize = config
+            .streaming_format
+            .map_or(StreamSize::U64maxNotChunked, |fmt| {
+                config
+                    .stream_size_for(fmt)
+                    .unwrap_or(StreamSize::NoneChunked)
+            });
         let streamsizes = StreamSize::ALL.map(StreamSize::as_str);
         let streamsize_str = streamsize.as_str();
         let initial_ss_idx = streamsizes
@@ -360,24 +357,15 @@ impl MainForm {
                 let streamsize = StreamSize::from_str(&newsize).unwrap();
                 let current = {
                     let cfg = get_config();
-                    match cfg.streaming_format.unwrap_or(StreamingFormat::Flac) {
-                        StreamingFormat::Lpcm => cfg.lpcm_stream_size,
-                        StreamingFormat::Wav => cfg.wav_stream_size,
-                        StreamingFormat::Rf64 => cfg.rf64_stream_size,
-                        StreamingFormat::Flac => cfg.flac_stream_size,
-                    }
+                    cfg.stream_size_for(cfg.streaming_format.unwrap_or(StreamingFormat::Flac))
                 };
                 if current == Some(streamsize) {
                     return;
                 }
                 let streaming_format = {
                     let mut conf = get_config_mut();
-                    match conf.streaming_format.unwrap_or(StreamingFormat::Flac) {
-                        StreamingFormat::Lpcm => conf.lpcm_stream_size = Some(streamsize),
-                        StreamingFormat::Wav => conf.wav_stream_size = Some(streamsize),
-                        StreamingFormat::Rf64 => conf.rf64_stream_size = Some(streamsize),
-                        StreamingFormat::Flac => conf.flac_stream_size = Some(streamsize),
-                    }
+                    let fmt = conf.streaming_format.unwrap_or(StreamingFormat::Flac);
+                    conf.set_stream_size_for(fmt, streamsize);
                     let _ = conf.update_config();
                     conf.streaming_format.unwrap()
                 };
@@ -1192,16 +1180,13 @@ impl MainForm {
             .map_or("lpcm".to_string(), |f| f.to_string());
         let bits = config.bits_per_sample.unwrap_or(16);
         let sample_rate = config.sample_rate.unwrap_or(default_sample_rate);
-        let streamsize = if let Some(fmt) = config.streaming_format {
-            match fmt {
-                StreamingFormat::Lpcm => config.lpcm_stream_size.unwrap_or(StreamSize::NoneChunked),
-                StreamingFormat::Wav => config.wav_stream_size.unwrap_or(StreamSize::NoneChunked),
-                StreamingFormat::Rf64 => config.rf64_stream_size.unwrap_or(StreamSize::NoneChunked),
-                StreamingFormat::Flac => config.flac_stream_size.unwrap_or(StreamSize::NoneChunked),
-            }
-        } else {
-            StreamSize::U64maxNotChunked
-        };
+        let streamsize = config
+            .streaming_format
+            .map_or(StreamSize::U64maxNotChunked, |fmt| {
+                config
+                    .stream_size_for(fmt)
+                    .unwrap_or(StreamSize::NoneChunked)
+            });
         let buf_ms = config.buffering_delay_msec.unwrap_or(0);
         let network = config.last_network.as_deref().unwrap_or("-");
         let port = config.server_port.unwrap_or_default();

--- a/src/utils/configuration.rs
+++ b/src/utils/configuration.rs
@@ -210,6 +210,27 @@ impl Configuration {
         self.config_dir.clone()
     }
 
+    /// Returns the configured `StreamSize` for the given streaming format.
+    #[must_use]
+    pub fn stream_size_for(&self, format: StreamingFormat) -> Option<StreamSize> {
+        match format {
+            StreamingFormat::Lpcm => self.lpcm_stream_size,
+            StreamingFormat::Wav => self.wav_stream_size,
+            StreamingFormat::Rf64 => self.rf64_stream_size,
+            StreamingFormat::Flac => self.flac_stream_size,
+        }
+    }
+
+    /// Sets the `StreamSize` for the given streaming format.
+    pub fn set_stream_size_for(&mut self, format: StreamingFormat, size: StreamSize) {
+        match format {
+            StreamingFormat::Lpcm => self.lpcm_stream_size = Some(size),
+            StreamingFormat::Wav => self.wav_stream_size = Some(size),
+            StreamingFormat::Rf64 => self.rf64_stream_size = Some(size),
+            StreamingFormat::Flac => self.flac_stream_size = Some(size),
+        }
+    }
+
     /// Resolves the config path (honouring CLI overrides) and loads it, creating a default file if absent.
     pub fn read_config() -> Result<Configuration> {
         let configfile = Self::choose_config_path()?;


### PR DESCRIPTION
  The per-format StreamSize match (Lpcm/Wav/Rf64/Flac) was duplicated across mainform.rs (three call sites), streaming.rs, and the CLI's argument handling. Centralize it as two methods on Configuration.