### PR TITLE
Upgrade to CPAL 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - GUI: properly resize the log textbox on renderer button insert
   - various minor refactorings
   - another SIMD optimization in TPDF dithering
+  - migrate to CPAL 0.19.0: `InputCallbackInfo`/`OutputCallbackInfo` are unified into `CallbackInfo`, `Stream::play()` is renamed to `Stream::start()`, and xrun detection moves from `Error::kind()` to `CallbackInfo::xrun()`
   - GUI: add SlimProto (SqueezeLite) support, enabled by default. Can be disabled in the APP Tab. Clients are discovered automatically and show up as renderer buttons in the GUI just like UPNP/DLNA renderers. The volume slider is write-only and always starts at 20%, you might have to increase it to hear sound. SqueezeLite clients do not advertise a volume. You need to allow the SlimProto TCP and UDP ports 3483 in the firewall for SqueezLite to work. Squeezelite has lower latency to start streaming that UPNP/DLNA. All swyh-rs audio formats are supported.
   - CLI: add SlimProto support (-P --slimproto default true). Volume is set at 20% unless specified with -v xx in the commandline.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ required-features = ["cli"]
 winres = "0.1.12"
 
 [dependencies]
-cpal = { version = "0.18.2" }
+cpal = { version = "0.19.0" }
 anyhow = "1"
 crossbeam-channel = "0.5.16"
 ctrlc = { version = "3.5.2", features = ["termination"] }
@@ -118,8 +118,9 @@ harness = false
 #figura = { git = "https://github.com/dheijl/figura_dh" }
 #fltk = { git = "https://github.com/fltk-rs/fltk-rs" }
 #tiny_http = { git = "https://github.com/tiny-http/tiny-http" }
+# with the cpal 0.18.2 release the cpal master branch became 0.19.0 development
 #cpal = { git = "https://github.com/RustAudio/cpal.git", branch = "develop" }
-#cpal = { git = "https://github.com/RustAudio/cpal.git" }
+cpal = { git = "https://github.com/RustAudio/cpal.git" }
 #flac-bound = { git = "https://github.com/dheijl/flac-bound" }
 #flac-bound = { git = "https://github.com/nabijaczleweli/flac-bound" }
 zmij = { git = "https://github.com/dtolnay/zmij" }

--- a/src/audio/audiodevices.rs
+++ b/src/audio/audiodevices.rs
@@ -12,7 +12,7 @@ use crate::{
     utils::ui_logger::{LogCategory, ui_log},
 };
 use cpal::{
-    Error, ErrorKind, InputCallbackInfo, Sample, SampleFormat, SizedSample, SupportedStreamConfig,
+    CallbackInfo, Error, Sample, SampleFormat, SizedSample, SupportedStreamConfig,
     traits::{DeviceTrait, HostTrait},
 };
 use crossbeam_channel::Sender;
@@ -313,7 +313,7 @@ pub fn capture_output_audio(
         cpal::SampleFormat::F32 => {
             let result = device.build_input_stream(
                 audio_cfg.config(),
-                move |data, info: &InputCallbackInfo| {
+                move |data, info: &CallbackInfo| {
                     wave_reader_f32(data, channels, &mut stereo_samples, &rms_sender, info)
                 },
                 capture_err_fn,
@@ -390,7 +390,7 @@ where
 {
     let result = device.build_input_stream(
         config,
-        move |data: &[T], info: &InputCallbackInfo| {
+        move |data: &[T], info: &CallbackInfo| {
             wave_reader::<T>(
                 data,
                 channels,
@@ -408,14 +408,10 @@ where
 
 /// `capture_err_fn` - called when it's impossible to start/continue streaming
 fn capture_err_fn(err: cpal::Error) {
-    if err.kind() == ErrorKind::Xrun {
-        warn!("Audio capture error: {err}");
-    } else {
-        ui_log(
-            LogCategory::Error,
-            &fl!("err-capture-stream", "error" = err.to_string()),
-        );
-    }
+    ui_log(
+        LogCategory::Error,
+        &fl!("err-capture-stream", "error" = err.to_string()),
+    );
     if err.kind() == cpal::ErrorKind::DeviceNotAvailable {
         get_msgchannel()
             .0
@@ -457,11 +453,14 @@ fn wave_reader<T>(
     f32_samples: &mut Vec<f32>,
     stereo_samples: &mut Vec<f32>,
     rms_sender: &Sender<AudioSamples>,
-    _info: &InputCallbackInfo,
+    info: &CallbackInfo,
 ) where
     T: Sample + ToSample<f32>,
 {
     ONFIRSTCALL.call_once(capture_started);
+    if info.xrun() {
+        warn!("Audio capture xrun error");
+    }
     f32_samples.clear();
     f32_samples.extend(samples.iter().map(|x: &T| T::to_sample::<f32>(*x)));
     if channels == 2 {
@@ -479,9 +478,12 @@ fn wave_reader_f32(
     channels: u16,
     stereo_samples: &mut Vec<f32>,
     rms_sender: &Sender<AudioSamples>,
-    _info: &InputCallbackInfo,
+    info: &CallbackInfo,
 ) {
     ONFIRSTCALL.call_once(capture_started);
+    if info.xrun() {
+        warn!("Audio capture xrun error");
+    }
     if channels == 2 {
         distribute_samples(samples, rms_sender);
     } else {

--- a/src/bin/swyh-rs-cli.rs
+++ b/src/bin/swyh-rs-cli.rs
@@ -149,7 +149,7 @@ fn main() -> Result<(), i32> {
         ui_log(LogCategory::Error, &fl!("err-capture-audio"));
         return Err(-2);
     };
-    stream.play().expect("Unable to play audio stream");
+    stream.start().expect("Unable to play audio stream");
 
     // If silence injector is on, create a silence injector stream and keep it alive
     let _silence_stream = {
@@ -441,7 +441,7 @@ fn main() -> Result<(), i32> {
                                 capture_output_audio(&audio_output_device, &audio_cfg, rms_chan2.0)
                             {
                                 stream = s;
-                                stream.play().expect("Unable to play audio stream");
+                                stream.start().expect("Unable to play audio stream");
                                 info!("Audio capture resumed.");
                                 break;
                             }

--- a/src/bin/swyh-rs.rs
+++ b/src/bin/swyh-rs.rs
@@ -148,7 +148,7 @@ fn main() {
         }
     }
     if let Some(ref s) = stream
-        && s.play().is_err()
+        && s.start().is_err()
     {
         ui_log(LogCategory::Error, &fl!("err-play-stream"));
     }
@@ -332,7 +332,7 @@ fn main() {
                         }
                     }
                     if let Some(ref s) = stream
-                        && s.play().is_err()
+                        && s.start().is_err()
                     {
                         ui_log(LogCategory::Error, &fl!("err-play-stream"));
                     }

--- a/src/utils/inject_silence.rs
+++ b/src/utils/inject_silence.rs
@@ -19,7 +19,10 @@ use crate::{
 pub fn run_silence_injector(device: &Device) -> Option<Stream> {
     // CPAL 0.15 switched to dasp_sample:
     // see https://github.com/RustAudio/cpal/commit/85d773d59f1725b25002c6f04aa2eb9b43a75b76#diff-babb62f9985b4798a655658e440a565984ce15b25e63a82fc4b3cc0b54fd2a02
-    fn write_silence<T: Sample>(data: &mut [T], _info: &cpal::OutputCallbackInfo) {
+    fn write_silence<T: Sample>(data: &mut [T], info: &cpal::CallbackInfo) {
+        if info.xrun() {
+            warn!("Inject silence xrun error");
+        }
         for sample in &mut *data {
             *sample = Sample::EQUILIBRIUM;
         }
@@ -28,14 +31,10 @@ pub fn run_silence_injector(device: &Device) -> Option<Stream> {
     let config = device.default_config();
     let sample_format = config.sample_format();
     let err_fn = |err: cpal::Error| {
-        if err.kind() == ErrorKind::Xrun {
-            warn!("Inject silence error: {err}");
-        } else {
-            ui_log(
-                LogCategory::Error,
-                &fl!("err-inject-silence-stream", "error" = err.to_string()),
-            )
-        }
+        ui_log(
+            LogCategory::Error,
+            &fl!("err-inject-silence-stream", "error" = err.to_string()),
+        )
     };
     let mut config = config.config();
     config.buffer_size = cpal::BufferSize::Fixed(4096);
@@ -59,7 +58,7 @@ pub fn run_silence_injector(device: &Device) -> Option<Stream> {
     };
     match try_stream {
         Ok(stream) => {
-            if stream.play().is_ok() {
+            if stream.start().is_ok() {
                 Some(stream)
             } else {
                 ui_log(LogCategory::Error, &fl!("err-inject-silence-play"));


### PR DESCRIPTION
## Summary
- Bump `cpal` to 0.19.0
- Migrate to the unified `CallbackInfo` type (replaces `InputCallbackInfo`/`OutputCallbackInfo`)
- Rename `Stream::play()` calls to `Stream::start()`
- Move xrun detection from `Error::kind() == ErrorKind::Xrun` to `CallbackInfo::xrun()` inside the audio/silence-injector callbacks

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --all-features`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`